### PR TITLE
Center preferences window header switcher

### DIFF
--- a/src/ui/preferences.ui
+++ b/src/ui/preferences.ui
@@ -295,12 +295,11 @@
         <property name="visible">True</property>
         <property name="can-focus">False</property>
         <property name="show-close-button">True</property>
-        <child>
+        <child type="title">
           <object class="GtkStackSwitcher" id="stack_switcher">
             <property name="visible">True</property>
             <property name="can-focus">False</property>
             <property name="halign">center</property>
-            <property name="hexpand">True</property>
             <property name="stack">stack</property>
           </object>
         </child>


### PR DESCRIPTION
Currently, header switcher in the preferences window is aligned to the left:
![Снимок экрана от 2021-02-26 13-27-37](https://user-images.githubusercontent.com/22382143/109288825-6ef43f80-7836-11eb-8d5e-92d45a1053dd.png)

I am not familiar with GTK, but this seems to be enough to make it centered.