### PR TITLE
Reset empty suffix to default value

### DIFF
--- a/src/preferences.py
+++ b/src/preferences.py
@@ -108,6 +108,8 @@ class CurtailPrefsWindow(Gtk.Window):
     def on_string_changed(self, entry, key):
         self._settings.set_string(key, entry.get_text())
         if key == 'suffix':
+            if not self._settings.get_string('suffix'):
+                self._settings.reset('suffix')
             self.parent.change_save_info_label()
 
     def on_int_changed(self, spin, key):


### PR DESCRIPTION
Fixes #63. In later versions, consider removing new-file setting and switch to overwrite mode on empty suffix.