### PR TITLE
Fix missing icon in XFCE, LXQt, MATE

### DIFF
--- a/src/window.py
+++ b/src/window.py
@@ -53,6 +53,7 @@ class CurtailWindow(Gtk.ApplicationWindow):
 
     def __init__(self, **kwargs):
         super().__init__(**kwargs)
+        self.set_default_icon_name('com.github.huluti.Curtail')
         self.app = kwargs['application']
 
         self.build_ui()


### PR DESCRIPTION
This fixes missing icons in window managers in XFCE, LXQt and MATE

Similar to https://github.com/rafaelmardojai/blanket/issues/54 and https://github.com/hugolabe/Wike/pull/9