### PR TITLE
Drag-and-drop fixes

### DIFF
--- a/src/tools.py
+++ b/src/tools.py
@@ -62,7 +62,7 @@ def add_filechooser_filters(dialog):
 
 
 def get_file_type(filename):
-    content_type, uncertain = Gio.content_type_guess(filename=filename)
+    content_type, uncertain = Gio.content_type_guess(filename=str(filename))
     if not uncertain:
         if content_type == 'image/jpeg':
             return 'jpg'

--- a/src/window.py
+++ b/src/window.py
@@ -72,7 +72,7 @@ class CurtailWindow(Gtk.ApplicationWindow):
         self.menu_button.set_menu_model(window_menu)
 
         # Mainbox - drag&drop
-        enforce_target = Gtk.TargetEntry.new('text/plain',
+        enforce_target = Gtk.TargetEntry.new('text/uri-list',
                                              Gtk.TargetFlags(4), 0)
         self.mainbox.drag_dest_set(Gtk.DestDefaults.ALL, [enforce_target],
                                    Gdk.DragAction.COPY)
@@ -183,8 +183,7 @@ class CurtailWindow(Gtk.ApplicationWindow):
            self.handle_filenames(filenames)
 
     def on_receive(self, widget, drag_context, x, y, data, info, time):
-        filenames = data.get_text()
-        filenames = filenames.split()  # we may have several paths
+        filenames = data.get_uris()
         self.handle_filenames(filenames)
 
     def handle_filenames(self, filenames):


### PR DESCRIPTION
- Fixes #77 and fixes #78 (please retest)
- Also fixes `TypeError: Must be string, not PosixPath`in `get_file_type` when drag-and-drop a directory. Error was introduced in commit 0c6602867a73ee5bf739a4bedcda2946ceb3f4d9