### PR TITLE
Add option to preserve file attributes if possible

### DIFF
--- a/data/com.github.huluti.Curtail.gschema.xml
+++ b/data/com.github.huluti.Curtail.gschema.xml
@@ -11,6 +11,11 @@
       <summary>Keep metadata</summary>
       <description>This setting preserves metadata of images.</description>
     </key>
+	  <key type="b" name="file-attributes">
+      <default>true</default>
+      <summary>Preserve file attributes if possible</summary>
+      <description>This setting preserves metadata of images.</description>
+    </key>
 	  <key type="b" name="lossy">
       <default>false</default>
       <summary>Enable lossy mode</summary>

--- a/src/compressor.py
+++ b/src/compressor.py
@@ -66,11 +66,12 @@ class Compressor():
             self.tree_iter = self.win.create_treeview_row(str(self.full_name), self.size)
             lossy = self._settings.get_boolean('lossy')
             metadata = self._settings.get_boolean('metadata')
+            file_attributes = self._settings.get_boolean('file-attributes')
 
             if file_type == 'png':
-                command = self.build_png_command(lossy, metadata)
+                command = self.build_png_command(lossy, metadata, file_attributes)
             elif file_type == 'jpg':
-                command = self.build_jpg_command(lossy, metadata)
+                command = self.build_jpg_command(lossy, metadata, file_attributes)
             elif file_type == 'webp':
                 command = self.build_webp_command(lossy, metadata)
             self.run_command(command)  # compress image
@@ -86,13 +87,16 @@ class Compressor():
         self.win.update_treeview_row(self.tree_iter, self.new_size,
                                     '{}%'.format(str(savings)))
 
-    def build_png_command(self, lossy, metadata):
+    def build_png_command(self, lossy, metadata, file_attributes):
         pngquant = 'pngquant --quality=0-{} -f "{}" --output "{}"'
         optipng = 'optipng -clobber -o{} "{}" -out "{}"'
 
         if not metadata:
             pngquant += ' --strip'
             optipng += ' -strip all'
+
+        if file_attributes:
+            optipng += ' -preserve'
 
         png_lossy_level = self._settings.get_int('png-lossy-level')
         png_lossless_level = self._settings.get_int('png-lossless-level')
@@ -108,7 +112,7 @@ class Compressor():
                                      self.new_filename)
         return command
 
-    def build_jpg_command(self, lossy, metadata):
+    def build_jpg_command(self, lossy, metadata, file_attributes):
         do_new_file = self._settings.get_boolean('new-file')
         do_jpg_progressive = self._settings.get_boolean('jpg-progressive')
 
@@ -126,6 +130,10 @@ class Compressor():
         if not metadata:
             jpegoptim += ' --strip-all'
             jpegoptim2 += ' --strip-all'
+
+        if file_attributes:
+            jpegoptim += ' --preserve --preserve-perms'
+            jpegoptim2 += ' --preserve --preserve-perms'
 
         jpg_lossy_level = self._settings.get_int('jpg-lossy-level')
         if lossy:  # lossy compression

--- a/src/preferences.py
+++ b/src/preferences.py
@@ -29,6 +29,7 @@ class CurtailPrefsWindow(Gtk.Window):
     __gtype_name__ = 'CurtailPrefsWindow'
 
     toggle_metadata = Gtk.Template.Child()
+    toggle_file_attributes = Gtk.Template.Child()
     toggle_new_file = Gtk.Template.Child()
     new_file_label = Gtk.Template.Child()
     entry_suffix = Gtk.Template.Child()
@@ -54,12 +55,17 @@ class CurtailPrefsWindow(Gtk.Window):
     def build_ui(self):
         # Compression settings
 
-        # Use new file
+        # Keep metadata
         self.toggle_metadata.set_active(self._settings.get_boolean('metadata'))
         self.toggle_metadata.connect('notify::active', self.on_bool_changed,
                                      'metadata')
 
-        # Keep metadata
+        # Preserve file attributes
+        self.toggle_file_attributes.set_active(self._settings.get_boolean('file-attributes'))
+        self.toggle_file_attributes.connect('notify::active', self.on_bool_changed,
+                                     'file-attributes')
+
+        # Use new file
         self.toggle_new_file.set_active(self._settings.get_boolean('new-file'))
         self.toggle_new_file.connect('notify::active', self.on_bool_changed,
                                      'new-file')

--- a/src/ui/preferences.ui
+++ b/src/ui/preferences.ui
@@ -12,13 +12,13 @@
     <property name="step-increment">1</property>
     <property name="page-increment">10</property>
   </object>
-  <object class="GtkAdjustment" id="webp_lossless_adj">
-    <property name="upper">6</property>
+  <object class="GtkAdjustment" id="png_lossy_adj">
+    <property name="upper">100</property>
     <property name="step-increment">1</property>
     <property name="page-increment">10</property>
   </object>
-  <object class="GtkAdjustment" id="png_lossy_adj">
-    <property name="upper">100</property>
+  <object class="GtkAdjustment" id="webp_lossless_adj">
+    <property name="upper">6</property>
     <property name="step-increment">1</property>
     <property name="page-increment">10</property>
   </object>
@@ -41,7 +41,7 @@
         <property name="margin-top">20</property>
         <property name="margin-bottom">20</property>
         <child>
-          <!-- n-columns=2 n-rows=4 -->
+          <!-- n-columns=2 n-rows=5 -->
           <object class="GtkGrid" id="grid1">
             <property name="visible">True</property>
             <property name="can-focus">False</property>
@@ -60,7 +60,7 @@
               </object>
               <packing>
                 <property name="left-attach">0</property>
-                <property name="top-attach">3</property>
+                <property name="top-attach">4</property>
               </packing>
             </child>
             <child>
@@ -73,7 +73,7 @@
               </object>
               <packing>
                 <property name="left-attach">1</property>
-                <property name="top-attach">3</property>
+                <property name="top-attach">4</property>
               </packing>
             </child>
             <child>
@@ -86,7 +86,7 @@
               </object>
               <packing>
                 <property name="left-attach">0</property>
-                <property name="top-attach">2</property>
+                <property name="top-attach">3</property>
               </packing>
             </child>
             <child>
@@ -97,7 +97,7 @@
               </object>
               <packing>
                 <property name="left-attach">1</property>
-                <property name="top-attach">2</property>
+                <property name="top-attach">3</property>
               </packing>
             </child>
             <child>
@@ -110,7 +110,7 @@
               </object>
               <packing>
                 <property name="left-attach">0</property>
-                <property name="top-attach">1</property>
+                <property name="top-attach">2</property>
               </packing>
             </child>
             <child>
@@ -123,7 +123,7 @@
               </object>
               <packing>
                 <property name="left-attach">1</property>
-                <property name="top-attach">1</property>
+                <property name="top-attach">2</property>
               </packing>
             </child>
             <child>
@@ -152,6 +152,32 @@
                 <property name="top-attach">0</property>
               </packing>
             </child>
+            <child>
+              <object class="GtkLabel">
+                <property name="visible">True</property>
+                <property name="can-focus">False</property>
+                <property name="halign">start</property>
+                <property name="valign">center</property>
+                <property name="label" translatable="yes">Preserve file attributes if possible</property>
+              </object>
+              <packing>
+                <property name="left-attach">0</property>
+                <property name="top-attach">1</property>
+              </packing>
+            </child>
+            <child>
+              <object class="GtkSwitch" id="toggle_file_attributes">
+                <property name="visible">True</property>
+                <property name="can-focus">True</property>
+                <property name="halign">end</property>
+                <property name="valign">center</property>
+                <property name="hexpand">True</property>
+              </object>
+              <packing>
+                <property name="left-attach">1</property>
+                <property name="top-attach">1</property>
+              </packing>
+            </child>
           </object>
           <packing>
             <property name="name">general</property>
@@ -159,7 +185,7 @@
           </packing>
         </child>
         <child>
-          <!-- n-columns=2 n-rows=2 -->
+          <!-- n-columns=2 n-rows=3 -->
           <object class="GtkGrid" id="grid2">
             <property name="visible">True</property>
             <property name="can-focus">False</property>
@@ -257,7 +283,7 @@
           </packing>
         </child>
         <child>
-          <!-- n-columns=2 n-rows=2 -->
+          <!-- n-columns=2 n-rows=3 -->
           <object class="GtkGrid" id="grid3">
             <property name="visible">True</property>
             <property name="can-focus">False</property>


### PR DESCRIPTION
Fix #103.

Applicable only for:
- PNG in lossless mode (optipng)
- JPG (jpegoptim)