### PR TITLE
Metadata: Add "optimize" for improved discoverability

### DIFF
--- a/data/com.github.huluti.Curtail.appdata.xml.in
+++ b/data/com.github.huluti.Curtail.appdata.xml.in
@@ -8,8 +8,8 @@
   <name translatable="no">Curtail</name>
   <summary>Compress your images</summary>
   <description>
-    <p>Curtail is an useful image compressor, supporting PNG, JPEG and WEBP file types.</p>
-    <p>It support both lossless and lossy compression modes with an option to whether keep or not metadata of images.</p>
+    <p>Optimize your images with Curtail, a useful image compressor that supports PNG, JPEG and WEBP file types.</p>
+    <p>It supports both lossless and lossy compression modes with an option to whether keep or not metadata of images.</p>
   </description>
 
   <developer_name translatable="no">Hugo Posnic</developer_name>

--- a/data/com.github.huluti.Curtail.desktop.in
+++ b/data/com.github.huluti.Curtail.desktop.in
@@ -10,3 +10,4 @@ Icon=com.github.huluti.Curtail
 StartupWMClass=curtail
 MimeType=image/jpeg;image/png;
 StartupNotify=true
+Keywords=compress;optimize;image;photo;


### PR DESCRIPTION
This will make Curtail easier to find in app stores, Flathub on the web, and in desktop search like in GNOME Shell. Fixes #128 