### PR TITLE
Update Debian dependencies for libadwaita

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -8,7 +8,8 @@ Build-Depends: debhelper-compat(=10),
 	meson (>= 0.50),
 	pkg-config,
 	libglib2.0-dev,
-	appstream
+	appstream,
+	libadwaita-1-dev
 Standards-Version: 4.5.0
 Rules-Requires-Root: no
 Homepage: https://github.com/Huluti/Curtail
@@ -18,7 +19,7 @@ Vcs-Git: https://github.com/Huluti/Curtail.git
 Package: curtail
 Architecture: all
 Depends: ${misc:Depends},
-	gir1.2-gtk-3.0,
+	gir1.2-adw-1,
 	python3,
 	optipng,
 	pngquant,


### PR DESCRIPTION
Builds in Launchpad without issues. https://code.launchpad.net/~apandada1/+archive/ubuntu/exp/+build/25691766
Also verified that the new .deb file works in Ubuntu 22.10.