### PR TITLE
Add ability to recursively compress all images in a directory

### DIFF
--- a/data/ui/menu.ui
+++ b/data/ui/menu.ui
@@ -3,6 +3,10 @@
   <menu id="window-menu">
     <section>
       <item>
+        <attribute name="label" translatable="yes">Bulk Convert Folder (Recursive)</attribute>
+        <attribute name="action">win.convert-dir</attribute>
+      </item>
+      <item>
         <attribute name="label" translatable="yes">Preferences</attribute>
         <attribute name="action">win.preferences</attribute>
       </item>

--- a/data/ui/menu.ui
+++ b/data/ui/menu.ui
@@ -3,7 +3,7 @@
   <menu id="window-menu">
     <section>
       <item>
-        <attribute name="label" translatable="yes">Bulk Convert Folder (Recursive)</attribute>
+        <attribute name="label" translatable="yes">Bulk Convert Directory (Recursive)</attribute>
         <attribute name="action">win.convert-dir</attribute>
       </item>
       <item>

--- a/data/ui/menu.ui
+++ b/data/ui/menu.ui
@@ -3,7 +3,7 @@
   <menu id="window-menu">
     <section>
       <item>
-        <attribute name="label" translatable="yes">Bulk Convert Directory (Recursive)</attribute>
+        <attribute name="label" translatable="yes">Bulk Compress Directory (Recursive)</attribute>
         <attribute name="action">win.convert-dir</attribute>
       </item>
       <item>

--- a/src/tools.py
+++ b/src/tools.py
@@ -19,6 +19,7 @@ import re
 import logging
 import platform
 import subprocess
+import os
 from gi.repository import Gtk, GLib, Gio, GdkPixbuf
 
 
@@ -111,6 +112,16 @@ def create_image_from_file(filename, max_width, max_height):
 
     return image
 
+def get_image_files_from_folder(folder_path):
+    images = []
+    for root, dirs, files in os.walk(folder_path):
+        for file in files:
+            path = os.path.join(root, file)
+            if get_file_type(path) != None:
+                image_file = Gio.File.new_for_path(path)
+                images.append(image_file)
+
+    return images
 
 def debug_infos():
     python_version = platform.python_version()

--- a/src/window.py
+++ b/src/window.py
@@ -23,7 +23,7 @@ from .resultitem import ResultItem
 from .preferences import CurtailPrefsWindow
 from .compressor import Compressor
 from .tools import add_filechooser_filters, get_file_type, \
-    create_image_from_file, sizeof_fmt, debug_infos
+    create_image_from_file, sizeof_fmt, debug_infos, get_image_files_from_folder
 
 CURTAIL_PATH = '/com/github/huluti/Curtail/'
 SETTINGS_SCHEMA = 'com.github.huluti.Curtail'
@@ -104,6 +104,7 @@ class CurtailWindow(Gtk.ApplicationWindow):
         self.create_simple_action('preferences', self.on_preferences, '<Primary>comma')
         self.create_simple_action('about', self.on_about)
         self.create_simple_action('quit', self.on_quit, '<Primary>q')
+        self.create_simple_action('convert-dir', self.on_select_folder, '<Primary>d')
 
     def enable_compression(self, enable):
         self.filechooser_button_headerbar.set_sensitive(enable)
@@ -200,6 +201,27 @@ class CurtailWindow(Gtk.ApplicationWindow):
                 self.compress_filenames(final_filenames)
 
         dialog.open_multiple(self, None, handle_response)
+
+    def on_select_folder(self, *args):
+        dialog = Gtk.FileDialog(title=_("Browse Directories"))
+
+        def handle_response(dialog, result):
+            try:
+                folders = dialog.select_multiple_folders_finish(result)
+            except GLib.Error as err:
+                print("Could not open files: %s", err.message)
+            else:
+                filenames = list()
+                for folder in folders:
+                    images = get_image_files_from_folder(folder.get_path())
+
+                    for image in images:
+                        filenames.append(image.get_uri())
+
+                final_filenames = self.handle_filenames(filenames)
+                self.compress_filenames(final_filenames)
+
+        dialog.select_multiple_folders(self, None, handle_response)
 
     def on_dnd_drop(self, drop_target, value, x, y, user_data=None):
         files = value.get_files()

--- a/src/window.py
+++ b/src/window.py
@@ -208,45 +208,50 @@ class CurtailWindow(Gtk.ApplicationWindow):
         def handle_response(dialog, result):
             def on_dir_dialog_response(warn_dialog, response):
                 if response == "compress":
-                    try:
-                        folders = dialog.select_multiple_folders_finish(result)
-                    except GLib.Error as err:
-                        print("Could not open files: %s", err.message)
-                    else:
-                        filenames = list()
-                        for folder in folders:
-                            images = get_image_files_from_folder(folder.get_path())
+                    filenames = list()
+                    for folder in folders:
+                        images = get_image_files_from_folder(folder.get_path())
 
-                            for image in images:
-                                filenames.append(image.get_uri())
+                        for image in images:
+                            filenames.append(image.get_uri())
 
-                        final_filenames = self.handle_filenames(filenames)
-                        self.compress_filenames(final_filenames)
+                    final_filenames = self.handle_filenames(filenames)
+                    self.compress_filenames(final_filenames)
 
-            warning_message_dialog = None
-            if self._settings.get_boolean('new-file'):
-                warning_message_dialog = Adw.MessageDialog.new(self,
-                    _("Are you sure you want to compress images in these directories?"),
-                    _("All of the images in the directories selected and their subdirectories will be converted. The original files will not be modified."))
+            try:
+                folders = dialog.select_multiple_folders_finish(result)
+            except GLib.Error as err:
+                print("Could not open files: %s", err.message)
             else:
-                warning_message_dialog = Adw.MessageDialog.new(self,
-                    _("Are you sure you want to compress images in these directories?"),
-                    _("All of the images in the directories selected and their subdirectories will be converted and overwritten!"))
-
-
-            warning_message_dialog.add_response("cancel", _("Cancel"))
-            warning_message_dialog.add_response("compress", _("Compress"))
-            warning_message_dialog.connect("response", on_dir_dialog_response)
-
-            if self._settings.get_boolean('new-file'):
-                warning_message_dialog.set_response_appearance("compress", Adw.ResponseAppearance.SUGGESTED)
-            else:
-                warning_message_dialog.set_response_appearance("compress", Adw.ResponseAppearance.DESTRUCTIVE)
-
-            warning_message_dialog.show()
+                warning_message_dialog = self._create_warning_dialog()
+                warning_message_dialog.connect("response", on_dir_dialog_response)
+                warning_message_dialog.show()
 
         dialog.select_multiple_folders(self, None, handle_response)
 
+    def _create_warning_dialog(self):
+        dialog = None
+        if self._settings.get_boolean('new-file'):
+            dialog = Adw.MessageDialog.new(self,
+                _("Are you sure you want to compress images in these directories?"),
+                _("All of the images in the directories selected and their "
+                "subdirectories will be compressed. The original images will not "
+                "be modified."))
+        else:
+            dialog = Adw.MessageDialog.new(self,
+                _("Are you sure you want to compress images in these directories?"),
+                _("All of the images in the directories selected and their "
+                "subdirectories will be compressed and overwritten!"))
+
+        dialog.add_response("cancel", _("Cancel"))
+        dialog.add_response("compress", _("Compress"))
+
+        if self._settings.get_boolean('new-file'):
+            dialog.set_response_appearance("compress", Adw.ResponseAppearance.SUGGESTED)
+        else:
+            dialog.set_response_appearance("compress", Adw.ResponseAppearance.DESTRUCTIVE)
+
+        return dialog
 
     def on_dnd_drop(self, drop_target, value, x, y, user_data=None):
         files = value.get_files()


### PR DESCRIPTION
Closes #150 
Added ability to select directories and convert all images in their subdirectories recursively through a menu button.

New menu action which prompts the user to select one or multiple directories:

![Menu](https://github.com/Huluti/Curtail/assets/106203063/ea4fd179-fa2d-48b4-ae99-714155733b02)

Confirmation dialog after a directory is selected by the user in safe mode:

![Safe Mode](https://github.com/Huluti/Curtail/assets/106203063/6cce93e9-5eae-491a-817b-1c9830a7b2ff)

Confirmation dialog after a directory is selected by the user when safe mode is disabled:

![Safe Mode Disabled](https://github.com/Huluti/Curtail/assets/106203063/1e81a379-16d1-4a34-a127-11411a03148c)

