### PR TITLE
metadata: Add source code link

### DIFF
--- a/data/com.github.huluti.Curtail.appdata.xml.in
+++ b/data/com.github.huluti.Curtail.appdata.xml.in
@@ -13,8 +13,9 @@
   </description>
   <developer_name translatable="no">Hugo Posnic</developer_name>
   <update_contact>hugo.posnic@protonmail.com</update_contact>
-  <url type="bugtracker">https://github.com/Huluti/Curtail/issues</url>
   <url type="homepage">https://github.com/Huluti/Curtail</url>
+  <url type="bugtracker">https://github.com/Huluti/Curtail/issues</url>
+  <url type="vcs-browser">https://github.com/Huluti/Curtail</url>
   <url type="donation">https://liberapay.com/hugoposnic</url>
   <url type="translate">https://github.com/Huluti/Curtail/tree/master/po</url>
   <kudos>


### PR DESCRIPTION
This link useful for the application centers like GNOME Software.

More information: https://www.freedesktop.org/software/appstream/docs/chap-Metadata.html#tag-url