### PR TITLE
Appdate related paches

### DIFF
--- a/data/com.github.huluti.Curtail.appdata.xml.in
+++ b/data/com.github.huluti.Curtail.appdata.xml.in
@@ -21,6 +21,15 @@
   <kudos>
     <kudo>ModernToolkit</kudo>
   </kudos>
+  <categories>
+    <category>Graphics</category>
+  </categories>
+  <keywords>
+    <keyword>compress</keyword>
+    <keyword>optimize</keyword>
+    <keyword>image</keyword>
+    <keyword>photo</keyword>
+  </keywords>
   <screenshots>
     <screenshot type="default">
       <image type="source">https://raw.githubusercontent.com/Huluti/Curtail/master/data/screenshots/screen1.png</image>

--- a/data/meson.build
+++ b/data/meson.build
@@ -33,9 +33,9 @@ appstream_file = i18n.merge_file(
   install_dir: join_paths(get_option('datadir'), 'metainfo')
 )
 
-appstream_util = find_program('appstream-util', required: false)
-if appstream_util.found()
-  test('Validate appstream file', appstream_util,
+appstreamcli = find_program('appstreamcli', required: false)
+if appstreamcli.found()
+  test('Validate appstream file', appstreamcli,
     args: ['validate', appstream_file]
   )
 endif


### PR DESCRIPTION
### appdata: Add categories and keywords support
- These tags may improve Software Center accessibility. More information: https://www.freedesktop.org/software/appstream/docs/chap-Metadata.html#tag-categories

### appdata: Use appstreamcli for appdata validation
- appstream-util is obsoleted by appstreamcli.