### PR TITLE
window: Use proper arrow character

### DIFF
--- a/src/window.py
+++ b/src/window.py
@@ -129,7 +129,7 @@ class CurtailWindow(Adw.ApplicationWindow):
         result_item.error = error
         if not error:
             result_item.savings = str(round(100 - (result_item.new_size * 100 / result_item.size), 2)) + '%'
-            result_item.subtitle_label += ' -> ' + sizeof_fmt(result_item.new_size)
+            result_item.subtitle_label += ' → ' + sizeof_fmt(result_item.new_size)
         else:
             result_item.subtitle_label = error_message
 


### PR DESCRIPTION
Looks like this in Cantarell:

![image](https://github.com/Huluti/Curtail/assets/93832451/12d12b1a-26ab-4148-85d5-45379032c9c4)
