### PR TITLE
appdata: Improve appdata for AppStream 1.0

### DIFF
--- a/data/com.github.huluti.Curtail.appdata.xml.in
+++ b/data/com.github.huluti.Curtail.appdata.xml.in
@@ -21,15 +21,6 @@
   <kudos>
     <kudo>ModernToolkit</kudo>
   </kudos>
-  <categories>
-    <category>Graphics</category>
-  </categories>
-  <keywords>
-    <keyword>compress</keyword>
-    <keyword>optimize</keyword>
-    <keyword>image</keyword>
-    <keyword>photo</keyword>
-  </keywords>
   <screenshots>
     <screenshot type="default">
       <image type="source">https://raw.githubusercontent.com/Huluti/Curtail/master/data/screenshots/screen1.png</image>

--- a/data/com.github.huluti.Curtail.appdata.xml.in
+++ b/data/com.github.huluti.Curtail.appdata.xml.in
@@ -11,7 +11,11 @@
     <p>Optimize your images with Curtail, a useful image compressor that supports PNG, JPEG, WebP and SVG file types.</p>
     <p>It supports both lossless and lossy compression modes with an option to whether keep or not metadata of images.</p>
   </description>
+  <!-- developer_name tag deprecated with Appstream 1.0 -->
   <developer_name translatable="no">Hugo Posnic</developer_name>
+  <developer id="github.com">
+    <name translatable="no">Hugo Posnic</name>
+  </developer>
   <update_contact>hugo.posnic@protonmail.com</update_contact>
   <url type="homepage">https://github.com/Huluti/Curtail</url>
   <url type="bugtracker">https://github.com/Huluti/Curtail/issues</url>
@@ -358,4 +362,3 @@
     </release>
   </releases>
 </component>
-

--- a/data/meson.build
+++ b/data/meson.build
@@ -36,7 +36,8 @@ appstream_file = i18n.merge_file(
 appstreamcli = find_program('appstreamcli', required: false)
 if appstreamcli.found()
   test('Validate appstream file', appstreamcli,
-    args: ['validate', appstream_file]
+    args: ['validate', '--no-net', '--explain', appstream_file],
+    workdir: meson.current_build_dir()
   )
 endif
 


### PR DESCRIPTION
### appdata: Improve appdata for AppStream 1.0

- Add the `<developer><name>` tag
- Mark the `<developer_name>` tag as deprecated
- Use --no-net argument for appstreamcli to reduce traffic

### appdata: Fix my mistake

"Icons and categories

If there’s a type="desktop-id" launchable, they get pulled from it.
Most of the icon not found errors with the flathub builder can be
traced down to the launchable value not matching the desktop file name.

Don’t set them in the AppData unless you want to override them
(even though then it might be a better idea to patch the desktop file
itself)."

More information: https://docs.flathub.org/docs/for-app-authors/appdata-guidelines/#icons-and-categories