### PR TITLE
Update developer ID

### DIFF
--- a/data/com.github.huluti.Curtail.appdata.xml.in
+++ b/data/com.github.huluti.Curtail.appdata.xml.in
@@ -12,7 +12,7 @@
   </description>
   <!-- developer_name tag deprecated with Appstream 1.0 -->
   <developer_name translatable="no">Hugo Posnic</developer_name>
-  <developer id="github.com">
+  <developer id="com.github.huluti">
     <name translatable="no">Hugo Posnic</name>
   </developer>
   <update_contact>hugo.posnic@protonmail.com</update_contact>


### PR DESCRIPTION
Appstream decided to use reverse DNS for developer IDs.

More information: ximion/appstream#575

https://www.freedesktop.org/software/appstream/docs/chap-Metadata.html#tag-developer