### PR TITLE
appdata: `translate=no` properties

### DIFF
--- a/data/com.github.huluti.Curtail.appdata.xml.in
+++ b/data/com.github.huluti.Curtail.appdata.xml.in
@@ -4,16 +4,16 @@
   <metadata_license>CC0-1.0</metadata_license>
   <project_license>GPL-3.0-or-later</project_license>
   <content_rating type="oars-1.1" />
-  <name translatable="no">Curtail</name>
+  <name translate="no">Curtail</name>
   <summary>Compress your images</summary>
   <description>
     <p>Optimize your images with Curtail, a useful image compressor that supports PNG, JPEG, WebP and SVG file types.</p>
     <p>It supports both lossless and lossy compression modes with an option to whether keep or not metadata of images.</p>
   </description>
   <!-- developer_name tag deprecated with Appstream 1.0 -->
-  <developer_name translatable="no">Hugo Posnic</developer_name>
+  <developer_name translate="no">Hugo Posnic</developer_name>
   <developer id="com.github.huluti">
-    <name translatable="no">Hugo Posnic</name>
+    <name translate="no">Hugo Posnic</name>
   </developer>
   <update_contact>hugo.posnic@protonmail.com</update_contact>
   <url type="homepage">https://github.com/Huluti/Curtail</url>
@@ -39,7 +39,7 @@
   <launchable type="desktop-id">com.github.huluti.Curtail.desktop</launchable>
   <releases>
     <release version="1.8.0" date="2023-10-03">
-      <description translatable="no">
+      <description translate="no">
         <p>Here's the changelog of this version:</p>
         <ul>
           <li>Add "Bulk Compress Directory (recursive)" feature. Thank's to @rk234</li>
@@ -55,7 +55,7 @@
       </description>
     </release>
     <release version="1.7.0" date="2023-04-05">
-      <description translatable="no">
+      <description translate="no">
         <p>Here's the changelog of this version:</p>
         <ul>
           <li>SVG support</li>
@@ -71,7 +71,7 @@
       </description>
     </release>
     <release version="1.6.0" date="2023-03-31">
-      <description translatable="no">
+      <description translate="no">
         <p>Here's the changelog of this version:</p>
         <ul>
           <li>Configurable compression timeout</li>
@@ -86,7 +86,7 @@
       </description>
     </release>
     <release version="1.5.0" date="2023-03-25">
-      <description translatable="no">
+      <description translate="no">
         <p>Here's the changelog of this version:</p>
         <ul>
           <li>More modern results page</li>
@@ -96,7 +96,7 @@
       </description>
     </release>
     <release version="1.4.0" date="2023-03-23">
-      <description translatable="no">
+      <description translate="no">
         <p>Here's the changelog of this version:</p>
         <ul>
           <li>Port to GTK 4 and Libadwaita</li>
@@ -107,7 +107,7 @@
       </description>
     </release>
     <release version="1.3.1" date="2022-07-12">
-      <description translatable="no">
+      <description translate="no">
         <p>Here's the changelog of this version:</p>
         <ul>
           <li>Make size columns sortable.</li>
@@ -121,7 +121,7 @@
       </description>
     </release>
     <release version="1.3.0" date="2022-05-01">
-      <description translatable="no">
+      <description translate="no">
         <p>Here's the changelog of this version:</p>
         <ul>
           <li>Add option to preserve file attributes if possible.</li>
@@ -132,7 +132,7 @@
       </description>
     </release>
     <release version="1.2.2" date="2021-11-13">
-      <description translatable="no">
+      <description translate="no">
         <p>Here's the changelog of this version:</p>
         <ul>
           <li>Add Turkish translation. Thank's to @05akalan57.</li>
@@ -149,7 +149,7 @@
       </description>
     </release>
     <release version="1.2.1" date="2021-07-04">
-      <description translatable="no">
+      <description translate="no">
         <p>Here's the changelog of this version:</p>
         <ul>
           <li>Add 'Apply to all queue' option for existing file dialog.</li>
@@ -158,7 +158,7 @@
       </description>
     </release>
     <release version="1.2.0" date="2021-06-29">
-      <description translatable="no">
+      <description translate="no">
         <p>Here's the changelog of this version:</p>
         <ul>
           <li>Add WebP support. Thank's to @olokelo.</li>
@@ -174,7 +174,7 @@
       </description>
     </release>
     <release version="1.1.0" date="2021-03-12">
-      <description translatable="no">
+      <description translate="no">
         <p>Here's the changelog of this version:</p>
         <ul>
           <li>An option to progressive encode jpegs. Thank's to @trst.</li>
@@ -192,7 +192,7 @@
       </description>
     </release>
     <release version="1.0.0" date="2020-12-19">
-      <description translatable="no">
+      <description translate="no">
         <p>Here's the changelog of this version:</p>
         <ul>
           <li>A new name. Thank's to @bertob, @jannuary and @jimmac.</li>
@@ -202,7 +202,7 @@
       </description>
     </release>
     <release version="0.8.4" date="2020-11-15">
-      <description translatable="no">
+      <description translate="no">
         <p>Here's the changelog of this version:</p>
         <ul>
           <li>Just fix a packaging file.</li>
@@ -210,7 +210,7 @@
       </description>
     </release>
     <release version="0.8.3" date="2020-11-14">
-      <description translatable="no">
+      <description translate="no">
         <p>Here's the changelog of this version:</p>
         <ul>
           <li>Just update GNOME runtime</li>
@@ -218,7 +218,7 @@
       </description>
     </release>
     <release version="0.8.2" date="2020-08-11">
-      <description translatable="no">
+      <description translate="no">
         <p>Here's the changelog of this version:</p>
         <ul>
           <li>Add Portuguese (Brazil) translation</li>
@@ -227,7 +227,7 @@
       </description>
     </release>
     <release version="0.8.1" date="2020-04-02">
-      <description translatable="no">
+      <description translate="no">
         <p>Here's the changelog of this version:</p>
         <ul>
           <li>Fix compression of jpg files that produced 0b files</li>
@@ -235,7 +235,7 @@
       </description>
     </release>
     <release version="0.8" date="2019-10-27">
-      <description translatable="no">
+      <description translate="no">
         <p>Here's the changelog of this version:</p>
         <ul>
           <li>Add an option to whether keep or not metadata of images</li>
@@ -245,7 +245,7 @@
       </description>
     </release>
     <release version="0.7" date="2019-10-25">
-      <description translatable="no">
+      <description translate="no">
         <p>Here's the changelog of this version:</p>
         <ul>
           <li>Add a spinner to indicate the progress of the compression</li>
@@ -256,7 +256,7 @@
       </description>
     </release>
     <release version="0.6" date="2019-10-21">
-      <description translatable="no">
+      <description translate="no">
         <p>Here's the changelog of this version:</p>
         <ul>
           <li>Add lossy compression features</li>
@@ -270,7 +270,7 @@
       </description>
     </release>
     <release version="0.5.2" date="2019-10-13">
-      <description translatable="no">
+      <description translate="no">
         <p>Here's the changelog of this version:</p>
         <ul>
           <li>Fix build</li>
@@ -278,7 +278,7 @@
       </description>
     </release>
     <release version="0.5.1" date="2019-10-13">
-      <description translatable="no">
+      <description translate="no">
         <p>Here's the changelog of this version:</p>
         <ul>
           <li>Fix opening files from file managers</li>
@@ -288,7 +288,7 @@
       </description>
     </release>
     <release version="0.5" date="2019-10-12">
-      <description translatable="no">
+      <description translate="no">
         <p>Here's the changelog of this version:</p>
         <ul>
           <li>Toggle the suffix entry according to new file option</li>
@@ -300,7 +300,7 @@
       </description>
     </release>
     <release version="0.4" date="2019-10-11">
-      <description translatable="no">
+      <description translate="no">
         <p>Here's the changelog of this version:</p>
         <ul>
           <li>Add a setting to change the '-min' suffix</li>
@@ -314,7 +314,7 @@
       </description>
     </release>
     <release version="0.3" date="2019-10-10">
-      <description translatable="no">
+      <description translate="no">
         <p>Here's the changelog of this version:</p>
         <ul>
           <li>Add a preferences window with new-file and dark-theme options</li>
@@ -323,7 +323,7 @@
       </description>
     </release>
     <release version="0.2.2" date="2019-10-10">
-      <description translatable="no">
+      <description translate="no">
         <p>Here's the changelog of this version:</p>
         <ul>
           <li>Permit to sort results by name or saving ratio</li>
@@ -332,7 +332,7 @@
       </description>
     </release>
     <release version="0.2.1" date="2019-10-09">
-      <description translatable="no">
+      <description translate="no">
         <p>Here's the changelog of this version:</p>
         <ul>
           <li>Stick back and forward buttons</li>
@@ -341,7 +341,7 @@
       </description>
     </release>
     <release version="0.2" date="2019-10-08">
-      <description translatable="no">
+      <description translate="no">
         <p>Here's the changelog of this version:</p>
         <ul>
           <li>Various optimizations</li>
@@ -352,7 +352,7 @@
       </description>
     </release>
     <release version="0.1" date="2019-10-08">
-      <description translatable="no">
+      <description translate="no">
         <p>Here's the changelog of this version:</p>
         <ul>
           <li>Initial version</li>


### PR DESCRIPTION
It appears that the appstream project no longer supports `translatable=no` properties, and gettext extract the `translatable=no` marked strings as translatable.

I opened an issue to inform about the situation, but `translatable=no` properties are not accepted by developers. You can find the issue here: https://github.com/ximion/appstream/issues/623

**Please test your script or string extraction process before merging this PR.**

> In MetaInfo files, each individual paragraph of a description
> (or enumerated entry) is translated individually, however,
> you can only exclude the complete block from being translated
> by adding `translate="no"` to the description element.

Source: https://freedesktop.org/software/appstream/docs/sect-Quickstart-Translation.html