### PR TITLE
Fix folder drag and drop

### DIFF
--- a/src/window.py
+++ b/src/window.py
@@ -282,6 +282,7 @@ class CurtailWindow(Adw.ApplicationWindow):
         return final_filenames
 
     def clean_filename(self, filename):
+        filename = str(filename)
         if filename.startswith('file://'):  # drag&drop
             filename = filename[7:]  # remove 'file://'
             filename = unquote(filename)  # remove %20


### PR DESCRIPTION
`filename` has to be a string in order for things to work, and some of the values from dragging and dropping a folder weren't for some reason.

Closes #166.