### PR TITLE
Add oxipng to debian dependencies

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -21,7 +21,7 @@ Architecture: all
 Depends: ${misc:Depends},
 	gir1.2-adw-1,
 	python3,
-	optipng,
+	oxipng,
 	pngquant,
 	jpegoptim,
 	webp


### PR DESCRIPTION
I have packaged the binary for oxipng in the PPA, and the latest version works with it. This change will pull oxipng as a dependency at the installation time.

(You don't have to release any new version for it. I will manually fix the PPA)