### PR TITLE
Fix opening files with Open With...

### DIFF
--- a/data/ui/window.ui
+++ b/data/ui/window.ui
@@ -3,6 +3,7 @@
   <template class="CurtailWindow" parent="AdwApplicationWindow">
     <property name="title" translatable="yes">Curtail</property>
     <property name="default-width">650</property>
+    <property name="default-height">500</property>
 
     <property name="content">
       <object class="AdwToolbarView">

--- a/src/main.py
+++ b/src/main.py
@@ -35,18 +35,17 @@ class Application(Adw.Application):
     def do_startup(self):
         Adw.Application.do_startup(self)
 
-        self.connect('open', self.file_open_handler)
-
     def do_activate(self):
         self.win = CurtailWindow(application=self)
         self.win.present()
 
-    def file_open_handler(self, app, g_file_list, amount, ukwn):
+    def do_open(self, g_file_list, amount, ukwn):
         self.do_activate()
         filenames = []
         for g_file in g_file_list:
             filenames.append(g_file.get_uri())
-        self.win.handle_filenames(filenames)
+        final_filenames = self.win.handle_filenames(filenames)
+        self.win.compress_filenames(final_filenames)
 
 
 def main(version):


### PR DESCRIPTION
Because of the way the `open` signal works, files can also be opened with the CLI now.

I added a default height to the window because it would load the window at a really small height when opening files this way. If my calculations are correct, the `default-height` it's 8 pixels bigger than the window usually opens. I did that because 500 is a nicer number than 492, and I don't think anyone will care or even notice. I also found that the method the `open` signal is connected to automatically runs if it's called `do_open()`, so I went ahead and edited that. If you want that change reverted, I can do that.

I'm also not sure where else to say this, but in the release for 1.9.0, you mentioned my old GitHub account instead of this one on accident. I got locked out of it a while ago and kind of forgot that it existed. My current username has a 1 instead of an I, which is admittedly a small change, but I just thought it'd be good for you to know. Sorry if this wasn't the right place to do it, I'm not sure where else to.

Closes #173.