### PR TITLE
Simplify UI code

### DIFF
--- a/data/ui/help_overlay.ui
+++ b/data/ui/help_overlay.ui
@@ -1,35 +1,35 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <interface>
   <object class="GtkShortcutsWindow" id="help_overlay">
-    <property name="modal">1</property>
+    <property name="modal">true</property>
     <child>
       <object class="GtkShortcutsSection">
         <property name="section-name">shortcuts</property>
         <property name="max-height">10</property>
         <child>
           <object class="GtkShortcutsGroup">
-            <property name="title" translatable="1" context="shortcut window">General</property>
+            <property name="title" translatable="yes" context="shortcut window">General</property>
             <child>
               <object class="GtkShortcutsShortcut">
-                <property name="title" translatable="1" context="shortcut window">Select File</property>
+                <property name="title" translatable="yes" context="shortcut window">Select File</property>
                 <property name="action-name">win.select-file</property>
               </object>
             </child>
             <child>
               <object class="GtkShortcutsShortcut">
-                <property name="title" translatable="1" context="shortcut window">Preferences</property>
+                <property name="title" translatable="yes" context="shortcut window">Preferences</property>
                 <property name="action-name">win.preferences</property>
               </object>
             </child>
             <child>
               <object class="GtkShortcutsShortcut">
-                <property name="title" translatable="1" context="shortcut window">Keyboard Shortcuts</property>
+                <property name="title" translatable="yes" context="shortcut window">Keyboard Shortcuts</property>
                 <property name="action-name">win.show-help-overlay</property>
               </object>
             </child>
             <child>
               <object class="GtkShortcutsShortcut">
-                <property name="title" translatable="1" context="shortcut window">Quit</property>
+                <property name="title" translatable="yes" context="shortcut window">Quit</property>
                 <property name="action-name">win.quit</property>
               </object>
             </child>

--- a/data/ui/help_overlay.ui
+++ b/data/ui/help_overlay.ui
@@ -1,35 +1,35 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <interface>
   <object class="GtkShortcutsWindow" id="help_overlay">
-    <property name="modal">true</property>
+    <property name="modal">1</property>
     <child>
       <object class="GtkShortcutsSection">
         <property name="section-name">shortcuts</property>
         <property name="max-height">10</property>
         <child>
           <object class="GtkShortcutsGroup">
-            <property name="title" translatable="yes" context="shortcut window">General</property>
+            <property name="title" translatable="1" context="shortcut window">General</property>
             <child>
               <object class="GtkShortcutsShortcut">
-                <property name="title" translatable="yes" context="shortcut window">Select File</property>
+                <property name="title" translatable="1" context="shortcut window">Select File</property>
                 <property name="action-name">win.select-file</property>
               </object>
             </child>
             <child>
               <object class="GtkShortcutsShortcut">
-                <property name="title" translatable="yes" context="shortcut window">Preferences</property>
+                <property name="title" translatable="1" context="shortcut window">Preferences</property>
                 <property name="action-name">win.preferences</property>
               </object>
             </child>
             <child>
               <object class="GtkShortcutsShortcut">
-                <property name="title" translatable="yes" context="shortcut window">Keyboard Shortcuts</property>
+                <property name="title" translatable="1" context="shortcut window">Keyboard Shortcuts</property>
                 <property name="action-name">win.show-help-overlay</property>
               </object>
             </child>
             <child>
               <object class="GtkShortcutsShortcut">
-                <property name="title" translatable="yes" context="shortcut window">Quit</property>
+                <property name="title" translatable="1" context="shortcut window">Quit</property>
                 <property name="action-name">win.quit</property>
               </object>
             </child>

--- a/data/ui/preferences.ui
+++ b/data/ui/preferences.ui
@@ -1,18 +1,18 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <interface domain="curtail">
   <template class="CurtailPrefsWindow" parent="AdwPreferencesWindow">
-    <property name="title" translatable="yes">Preferences</property>
+    <property name="title" translatable="1">Preferences</property>
     <child>
       <object class="AdwPreferencesPage">
         <property name="name">general</property>
-        <property name="title" translatable="yes">General</property>
+        <property name="title" translatable="1">General</property>
         <property name="icon-name">applications-system-symbolic</property>
         <child>
           <object class="AdwPreferencesGroup">
             <child>
               <object class="AdwActionRow">
-                <property name="title" translatable="yes">Safe Mode</property>
-                <property name="subtitle" translatable="yes">Save the compressed image in a new file</property>
+                <property name="title" translatable="1">Safe Mode</property>
+                <property name="subtitle" translatable="1">Save the compressed image in a new file</property>
                 <property name="activatable-widget">toggle_new_file</property>
                 <child>
                   <object class="GtkSwitch" id="toggle_new_file">
@@ -23,13 +23,13 @@
             </child>
             <child>
               <object class="AdwEntryRow" id="entry_suffix">
-                <property name="title" translatable="yes">New File Suffix</property>
+                <property name="title" translatable="1">New File Suffix</property>
               </object>
             </child>
             <child>
               <object class="AdwActionRow">
-                <property name="title" translatable="yes">Keep Metadata</property>
-                <property name="subtitle" translatable="yes">Keep metadata chunks that do not affect rendering</property>
+                <property name="title" translatable="1">Keep Metadata</property>
+                <property name="subtitle" translatable="1">Keep metadata chunks that do not affect rendering</property>
                 <property name="activatable-widget">toggle_metadata</property>
                 <child>
                   <object class="GtkSwitch" id="toggle_metadata">
@@ -40,8 +40,8 @@
             </child>
             <child>
               <object class="AdwActionRow">
-                <property name="title" translatable="yes">Keep File Attributes When Possible</property>
-                <property name="subtitle" translatable="yes">Ensure the new file has the same permissions and timestamps as the original file</property>
+                <property name="title" translatable="1">Keep File Attributes When Possible</property>
+                <property name="subtitle" translatable="1">Ensure the new file has the same permissions and timestamps as the original file</property>
                 <property name="activatable-widget">toggle_file_attributes</property>
                 <child>
                   <object class="GtkSwitch" id="toggle_file_attributes">
@@ -52,8 +52,8 @@
             </child>
             <child>
               <object class="AdwActionRow">
-                <property name="title" translatable="yes">Compression Timeout</property>
-                <property name="subtitle" translatable="yes">Set the timeout between images</property>
+                <property name="title" translatable="1">Compression Timeout</property>
+                <property name="subtitle" translatable="1">Set the timeout between images</property>
                 <property name="activatable-widget">spin_timeout</property>
                 <child>
                   <object class="GtkSpinButton" id="spin_timeout">
@@ -77,21 +77,20 @@
     <child>
       <object class="AdwPreferencesPage">
         <property name="name">compression</property>
-        <property name="title" translatable="yes">Compression</property>
+        <property name="title" translatable="1">Compression</property>
         <property name="icon-name">image-x-generic-symbolic</property>
         <child>
           <object class="AdwPreferencesGroup">
-            <property name="title" translatable="no">PNG</property>
+            <property name="title" translatable="0">PNG</property>
             <child>
               <object class="AdwActionRow">
-                <property name="title" translatable="yes">Lossy Compression</property>
-                <property name="subtitle" translatable="yes">Set the quality of the generated image, 100 is the best quality</property>
+                <property name="title" translatable="1">Lossy Compression</property>
+                <property name="subtitle" translatable="1">Set the quality of the generated image, 100 is the best quality</property>
                 <property name="activatable-widget">spin_png_lossy_level</property>
                 <child>
                   <object class="GtkSpinButton" id="spin_png_lossy_level">
                     <property name="adjustment">
                       <object class="GtkAdjustment" id="png_lossy_adj">
-                        <property name="lower">0</property>
                         <property name="upper">100</property>
                         <property name="step-increment">1</property>
                         <property name="page-increment">10</property>
@@ -104,14 +103,13 @@
             </child>
             <child>
               <object class="AdwActionRow">
-                <property name="title" translatable="yes">Lossless Compression Level</property>
-                <property name="subtitle" translatable="yes">Set the level of the compression, 6 is the highest but slowest level</property>
+                <property name="title" translatable="1">Lossless Compression Level</property>
+                <property name="subtitle" translatable="1">Set the level of the compression, 6 is the highest but slowest level</property>
                 <property name="activatable-widget">spin_png_lossless_level</property>
                 <child>
                   <object class="GtkSpinButton" id="spin_png_lossless_level">
                     <property name="adjustment">
                       <object class="GtkAdjustment" id="png_lossless_adj">
-                        <property name="lower">0</property>
                         <property name="upper">6</property>
                         <property name="step-increment">1</property>
                         <property name="page-increment">10</property>
@@ -126,17 +124,16 @@
         </child>
         <child>
           <object class="AdwPreferencesGroup">
-            <property name="title" translatable="no">JPG</property>
+            <property name="title" translatable="0">JPG</property>
             <child>
               <object class="AdwActionRow">
-                <property name="title" translatable="yes">Lossy Compression</property>
-                <property name="subtitle" translatable="yes">Set the quality of the generated image, 100 is the best quality</property>
+                <property name="title" translatable="1">Lossy Compression</property>
+                <property name="subtitle" translatable="1">Set the quality of the generated image, 100 is the best quality</property>
                 <property name="activatable-widget">spin_jpg_lossy_level</property>
                 <child>
                   <object class="GtkSpinButton" id="spin_jpg_lossy_level">
                     <property name="adjustment">
                       <object class="GtkAdjustment" id="jpg_lossy_adj">
-                        <property name="lower">0</property>
                         <property name="upper">100</property>
                         <property name="step-increment">1</property>
                         <property name="page-increment">10</property>
@@ -149,8 +146,8 @@
             </child>
             <child>
               <object class="AdwActionRow">
-                <property name="title" translatable="yes">Progressive Encode</property>
-                <property name="subtitle" translatable="yes">Enable incremental image rendering, going from blurry to clear</property>
+                <property name="title" translatable="1">Progressive Encode</property>
+                <property name="subtitle" translatable="1">Enable incremental image rendering, going from blurry to clear</property>
                 <property name="activatable-widget">toggle_jpg_progressive</property>
                 <child>
                   <object class="GtkSwitch" id="toggle_jpg_progressive">
@@ -163,17 +160,16 @@
         </child>
         <child>
           <object class="AdwPreferencesGroup">
-            <property name="title" translatable="no">WebP</property>
+            <property name="title" translatable="0">WebP</property>
             <child>
               <object class="AdwActionRow">
-                <property name="title" translatable="yes">Lossy Compression</property>
-                <property name="subtitle" translatable="yes">Set the quality of the generated image, 100 is the best quality</property>
+                <property name="title" translatable="1">Lossy Compression</property>
+                <property name="subtitle" translatable="1">Set the quality of the generated image, 100 is the best quality</property>
                 <property name="activatable-widget">spin_webp_lossy_level</property>
                 <child>
                   <object class="GtkSpinButton" id="spin_webp_lossy_level">
                     <property name="adjustment">
                       <object class="GtkAdjustment" id="webp_lossy_adj">
-                        <property name="lower">0</property>
                         <property name="upper">100</property>
                         <property name="step-increment">1</property>
                         <property name="page-increment">10</property>
@@ -186,14 +182,13 @@
             </child>
             <child>
               <object class="AdwActionRow">
-                <property name="title" translatable="yes">Lossless Compression Level</property>
-                <property name="subtitle" translatable="yes">Set the level of the compression, 6 is the highest but slowest level</property>
+                <property name="title" translatable="1">Lossless Compression Level</property>
+                <property name="subtitle" translatable="1">Set the level of the compression, 6 is the highest but slowest level</property>
                 <property name="activatable-widget">spin_webp_lossless_level</property>
                 <child>
                   <object class="GtkSpinButton" id="spin_webp_lossless_level">
                     <property name="adjustment">
                       <object class="GtkAdjustment" id="webp_lossless_adj">
-                        <property name="lower">0</property>
                         <property name="upper">6</property>
                         <property name="step-increment">1</property>
                         <property name="page-increment">10</property>
@@ -208,11 +203,11 @@
         </child>
         <child>
           <object class="AdwPreferencesGroup">
-            <property name="title" translatable="no">SVG</property>
+            <property name="title" translatable="0">SVG</property>
             <child>
               <object class="AdwActionRow">
-                <property name="title" translatable="yes">Maximum Compression Level</property>
-                <property name="subtitle" translatable="yes">This can be more destructive for the image</property>
+                <property name="title" translatable="1">Maximum Compression Level</property>
+                <property name="subtitle" translatable="1">This can be more destructive for the image</property>
                 <child>
                   <object class="GtkSwitch" id="toggle_svg_maximum_level">
                     <property name="valign">center</property>
@@ -226,4 +221,3 @@
     </child>
   </template>
 </interface>
-

--- a/data/ui/preferences.ui
+++ b/data/ui/preferences.ui
@@ -1,18 +1,18 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <interface domain="curtail">
   <template class="CurtailPrefsWindow" parent="AdwPreferencesWindow">
-    <property name="title" translatable="1">Preferences</property>
+    <property name="title" translatable="yes">Preferences</property>
     <child>
       <object class="AdwPreferencesPage">
         <property name="name">general</property>
-        <property name="title" translatable="1">General</property>
+        <property name="title" translatable="yes">General</property>
         <property name="icon-name">applications-system-symbolic</property>
         <child>
           <object class="AdwPreferencesGroup">
             <child>
               <object class="AdwActionRow">
-                <property name="title" translatable="1">Safe Mode</property>
-                <property name="subtitle" translatable="1">Save the compressed image in a new file</property>
+                <property name="title" translatable="yes">Safe Mode</property>
+                <property name="subtitle" translatable="yes">Save the compressed image in a new file</property>
                 <property name="activatable-widget">toggle_new_file</property>
                 <child>
                   <object class="GtkSwitch" id="toggle_new_file">
@@ -23,13 +23,13 @@
             </child>
             <child>
               <object class="AdwEntryRow" id="entry_suffix">
-                <property name="title" translatable="1">New File Suffix</property>
+                <property name="title" translatable="yes">New File Suffix</property>
               </object>
             </child>
             <child>
               <object class="AdwActionRow">
-                <property name="title" translatable="1">Keep Metadata</property>
-                <property name="subtitle" translatable="1">Keep metadata chunks that do not affect rendering</property>
+                <property name="title" translatable="yes">Keep Metadata</property>
+                <property name="subtitle" translatable="yes">Keep metadata chunks that do not affect rendering</property>
                 <property name="activatable-widget">toggle_metadata</property>
                 <child>
                   <object class="GtkSwitch" id="toggle_metadata">
@@ -40,8 +40,8 @@
             </child>
             <child>
               <object class="AdwActionRow">
-                <property name="title" translatable="1">Keep File Attributes When Possible</property>
-                <property name="subtitle" translatable="1">Ensure the new file has the same permissions and timestamps as the original file</property>
+                <property name="title" translatable="yes">Keep File Attributes When Possible</property>
+                <property name="subtitle" translatable="yes">Ensure the new file has the same permissions and timestamps as the original file</property>
                 <property name="activatable-widget">toggle_file_attributes</property>
                 <child>
                   <object class="GtkSwitch" id="toggle_file_attributes">
@@ -52,8 +52,8 @@
             </child>
             <child>
               <object class="AdwActionRow">
-                <property name="title" translatable="1">Compression Timeout</property>
-                <property name="subtitle" translatable="1">Set the timeout between images</property>
+                <property name="title" translatable="yes">Compression Timeout</property>
+                <property name="subtitle" translatable="yes">Set the timeout between images</property>
                 <property name="activatable-widget">spin_timeout</property>
                 <child>
                   <object class="GtkSpinButton" id="spin_timeout">
@@ -77,15 +77,15 @@
     <child>
       <object class="AdwPreferencesPage">
         <property name="name">compression</property>
-        <property name="title" translatable="1">Compression</property>
+        <property name="title" translatable="yes">Compression</property>
         <property name="icon-name">image-x-generic-symbolic</property>
         <child>
           <object class="AdwPreferencesGroup">
-            <property name="title" translatable="0">PNG</property>
+            <property name="title" translatable="no">PNG</property>
             <child>
               <object class="AdwActionRow">
-                <property name="title" translatable="1">Lossy Compression</property>
-                <property name="subtitle" translatable="1">Set the quality of the generated image, 100 is the best quality</property>
+                <property name="title" translatable="yes">Lossy Compression</property>
+                <property name="subtitle" translatable="yes">Set the quality of the generated image, 100 is the best quality</property>
                 <property name="activatable-widget">spin_png_lossy_level</property>
                 <child>
                   <object class="GtkSpinButton" id="spin_png_lossy_level">
@@ -103,8 +103,8 @@
             </child>
             <child>
               <object class="AdwActionRow">
-                <property name="title" translatable="1">Lossless Compression Level</property>
-                <property name="subtitle" translatable="1">Set the level of the compression, 6 is the highest but slowest level</property>
+                <property name="title" translatable="yes">Lossless Compression Level</property>
+                <property name="subtitle" translatable="yes">Set the level of the compression, 6 is the highest but slowest level</property>
                 <property name="activatable-widget">spin_png_lossless_level</property>
                 <child>
                   <object class="GtkSpinButton" id="spin_png_lossless_level">
@@ -124,11 +124,11 @@
         </child>
         <child>
           <object class="AdwPreferencesGroup">
-            <property name="title" translatable="0">JPG</property>
+            <property name="title" translatable="no">JPG</property>
             <child>
               <object class="AdwActionRow">
-                <property name="title" translatable="1">Lossy Compression</property>
-                <property name="subtitle" translatable="1">Set the quality of the generated image, 100 is the best quality</property>
+                <property name="title" translatable="yes">Lossy Compression</property>
+                <property name="subtitle" translatable="yes">Set the quality of the generated image, 100 is the best quality</property>
                 <property name="activatable-widget">spin_jpg_lossy_level</property>
                 <child>
                   <object class="GtkSpinButton" id="spin_jpg_lossy_level">
@@ -146,8 +146,8 @@
             </child>
             <child>
               <object class="AdwActionRow">
-                <property name="title" translatable="1">Progressive Encode</property>
-                <property name="subtitle" translatable="1">Enable incremental image rendering, going from blurry to clear</property>
+                <property name="title" translatable="yes">Progressive Encode</property>
+                <property name="subtitle" translatable="yes">Enable incremental image rendering, going from blurry to clear</property>
                 <property name="activatable-widget">toggle_jpg_progressive</property>
                 <child>
                   <object class="GtkSwitch" id="toggle_jpg_progressive">
@@ -160,11 +160,11 @@
         </child>
         <child>
           <object class="AdwPreferencesGroup">
-            <property name="title" translatable="0">WebP</property>
+            <property name="title" translatable="no">WebP</property>
             <child>
               <object class="AdwActionRow">
-                <property name="title" translatable="1">Lossy Compression</property>
-                <property name="subtitle" translatable="1">Set the quality of the generated image, 100 is the best quality</property>
+                <property name="title" translatable="yes">Lossy Compression</property>
+                <property name="subtitle" translatable="yes">Set the quality of the generated image, 100 is the best quality</property>
                 <property name="activatable-widget">spin_webp_lossy_level</property>
                 <child>
                   <object class="GtkSpinButton" id="spin_webp_lossy_level">
@@ -182,8 +182,8 @@
             </child>
             <child>
               <object class="AdwActionRow">
-                <property name="title" translatable="1">Lossless Compression Level</property>
-                <property name="subtitle" translatable="1">Set the level of the compression, 6 is the highest but slowest level</property>
+                <property name="title" translatable="yes">Lossless Compression Level</property>
+                <property name="subtitle" translatable="yes">Set the level of the compression, 6 is the highest but slowest level</property>
                 <property name="activatable-widget">spin_webp_lossless_level</property>
                 <child>
                   <object class="GtkSpinButton" id="spin_webp_lossless_level">
@@ -203,11 +203,11 @@
         </child>
         <child>
           <object class="AdwPreferencesGroup">
-            <property name="title" translatable="0">SVG</property>
+            <property name="title" translatable="no">SVG</property>
             <child>
               <object class="AdwActionRow">
-                <property name="title" translatable="1">Maximum Compression Level</property>
-                <property name="subtitle" translatable="1">This can be more destructive for the image</property>
+                <property name="title" translatable="yes">Maximum Compression Level</property>
+                <property name="subtitle" translatable="yes">This can be more destructive for the image</property>
                 <child>
                   <object class="GtkSwitch" id="toggle_svg_maximum_level">
                     <property name="valign">center</property>

--- a/data/ui/window.ui
+++ b/data/ui/window.ui
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <interface domain="curtail">
   <template class="CurtailWindow" parent="AdwApplicationWindow">
-    <property name="title" translatable="1">Curtail</property>
+    <property name="title" translatable="yes">Curtail</property>
     <property name="default-width">650</property>
     <property name="default-height">500</property>
     <property name="content">
@@ -14,28 +14,28 @@
                   <object class="GtkButton" id="filechooser_button_headerbar">
                     <property name="icon-name">document-open-symbolic</property>
                     <property name="action-name">win.select-file</property>
-                    <property name="tooltip-text" translatable="1">Browse Files</property>
+                    <property name="tooltip-text" translatable="yes">Browse Files</property>
                   </object>
                 </child>
                 <child>
                   <object class="GtkButton" id="clear_button_headerbar">
                     <property name="icon-name">view-refresh-symbolic</property>
                     <property name="action-name">win.clear-results</property>
-                    <property name="tooltip-text" translatable="1">Clear Results</property>
+                    <property name="tooltip-text" translatable="yes">Clear Results</property>
                   </object>
                 </child>
               </object>
             </child>
             <child type="title">
               <object class="AdwWindowTitle" id="window_title">
-                <property name="title" translatable="1">Curtail</property>
+                <property name="title" translatable="yes">Curtail</property>
               </object>
             </child>
             <child type="end">
               <object class="GtkMenuButton" id="menu_button">
                 <property name="icon-name">open-menu-symbolic</property>
-                <property name="primary">1</property>
-                <property name="tooltip-text" translatable="1">Main Menu</property>
+                <property name="primary">true</property>
+                <property name="tooltip-text" translatable="yes">Main Menu</property>
               </object>
             </child>
           </object>
@@ -46,22 +46,22 @@
             <child>
               <object class="AdwBanner" id="warning_banner">
                 <property name="action-name">win.preferences</property>
-                <property name="button-label" translatable="1">_Change Mode</property>
-                <property name="title" translatable="1">Images will be overwritten, proceed carefully</property>
+                <property name="button-label" translatable="yes">_Change Mode</property>
+                <property name="title" translatable="yes">Images will be overwritten, proceed carefully</property>
               </object>
             </child>
             <child>
               <object class="AdwStatusPage" id="homebox">
                 <property name="vexpand">true</property>
                 <property name="icon-name">com.github.huluti.Curtail</property>
-                <property name="title" translatable="0">Curtail</property>
-                <property name="description" translatable="1">Drop images here to compress them</property>
+                <property name="title" translatable="no">Curtail</property>
+                <property name="description" translatable="yes">Drop images here to compress them</property>
                 <child>
                   <object class="GtkBox">
                     <property name="orientation">vertical</property>
                     <child>
                       <object class="GtkButton">
-                        <property name="label" translatable="1">_Browse Files</property>
+                        <property name="label" translatable="yes">_Browse Files</property>
                         <property name="halign">center</property>
                         <property name="action-name">win.select-file</property>
                         <property name="margin-bottom">40</property>
@@ -80,7 +80,7 @@
                         <child>
                           <object class="GtkLabel">
                             <property name="halign">end</property>
-                            <property name="label" translatable="1">Lossless</property>
+                            <property name="label" translatable="yes">Lossless</property>
                           </object>
                         </child>
                         <child>
@@ -92,7 +92,7 @@
                         <child>
                           <object class="GtkLabel">
                             <property name="halign">start</property>
-                            <property name="label" translatable="1">Lossy</property>
+                            <property name="label" translatable="yes">Lossy</property>
                           </object>
                         </child>
                       </object>
@@ -108,7 +108,7 @@
               <object class="GtkBox" id="resultbox">
                 <child>
                   <object class="GtkScrolledWindow" id="scrolled_window">
-                    <property name="vexpand">1</property>
+                    <property name="vexpand">true</property>
                     <property name="hscrollbar-policy">never</property>
                     <child>
                       <object class="AdwClamp">
@@ -118,7 +118,7 @@
                         <property name="margin-bottom">20</property>
                         <child>
                           <object class="GtkListBox" id="listbox">
-                            <property name="hexpand">1</property>
+                            <property name="hexpand">true</property>
                             <property name="valign">start</property>
                             <property name="selection-mode">none</property>
                             <style>

--- a/data/ui/window.ui
+++ b/data/ui/window.ui
@@ -1,13 +1,11 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <interface domain="curtail">
   <template class="CurtailWindow" parent="AdwApplicationWindow">
-    <property name="title" translatable="yes">Curtail</property>
+    <property name="title" translatable="1">Curtail</property>
     <property name="default-width">650</property>
     <property name="default-height">500</property>
-
     <property name="content">
       <object class="AdwToolbarView">
-
         <child type="top">
           <object class="AdwHeaderBar" id="headerbar">
             <child>
@@ -16,55 +14,54 @@
                   <object class="GtkButton" id="filechooser_button_headerbar">
                     <property name="icon-name">document-open-symbolic</property>
                     <property name="action-name">win.select-file</property>
-                    <property name="tooltip-text" translatable="yes">Browse Files</property>
+                    <property name="tooltip-text" translatable="1">Browse Files</property>
                   </object>
                 </child>
                 <child>
                   <object class="GtkButton" id="clear_button_headerbar">
                     <property name="icon-name">view-refresh-symbolic</property>
                     <property name="action-name">win.clear-results</property>
-                    <property name="tooltip-text" translatable="yes">Clear Results</property>
+                    <property name="tooltip-text" translatable="1">Clear Results</property>
                   </object>
                 </child>
               </object>
             </child>
             <child type="title">
               <object class="AdwWindowTitle" id="window_title">
-                  <property name="title" translatable="yes">Curtail</property>
+                <property name="title" translatable="1">Curtail</property>
               </object>
             </child>
             <child type="end">
               <object class="GtkMenuButton" id="menu_button">
-                  <property name="icon-name">open-menu-symbolic</property>
-                  <property name="primary">true</property>
-                  <property name="tooltip-text" translatable="yes">Main Menu</property>
+                <property name="icon-name">open-menu-symbolic</property>
+                <property name="primary">1</property>
+                <property name="tooltip-text" translatable="1">Main Menu</property>
               </object>
             </child>
           </object>
         </child>
-
         <property name="content">
           <object class="GtkBox" id="mainbox">
             <property name="orientation">vertical</property>
             <child>
               <object class="AdwBanner" id="warning_banner">
                 <property name="action-name">win.preferences</property>
-                <property name="button-label" translatable="yes">_Change Mode</property>
-                <property name="title" translatable="yes">Images will be overwritten, proceed carefully</property>
+                <property name="button-label" translatable="1">_Change Mode</property>
+                <property name="title" translatable="1">Images will be overwritten, proceed carefully</property>
               </object>
             </child>
             <child>
               <object class="AdwStatusPage" id="homebox">
                 <property name="vexpand">true</property>
                 <property name="icon-name">com.github.huluti.Curtail</property>
-                <property name="title" translatable="no">Curtail</property>
-                <property name="description" translatable="yes">Drop images here to compress them</property>
+                <property name="title" translatable="0">Curtail</property>
+                <property name="description" translatable="1">Drop images here to compress them</property>
                 <child>
                   <object class="GtkBox">
                     <property name="orientation">vertical</property>
                     <child>
                       <object class="GtkButton">
-                        <property name="label" translatable="yes">_Browse Files</property>
+                        <property name="label" translatable="1">_Browse Files</property>
                         <property name="halign">center</property>
                         <property name="action-name">win.select-file</property>
                         <property name="margin-bottom">40</property>
@@ -83,7 +80,7 @@
                         <child>
                           <object class="GtkLabel">
                             <property name="halign">end</property>
-                            <property name="label" translatable="yes">Lossless</property>
+                            <property name="label" translatable="1">Lossless</property>
                           </object>
                         </child>
                         <child>
@@ -95,7 +92,7 @@
                         <child>
                           <object class="GtkLabel">
                             <property name="halign">start</property>
-                            <property name="label" translatable="yes">Lossy</property>
+                            <property name="label" translatable="1">Lossy</property>
                           </object>
                         </child>
                       </object>
@@ -111,7 +108,7 @@
               <object class="GtkBox" id="resultbox">
                 <child>
                   <object class="GtkScrolledWindow" id="scrolled_window">
-                    <property name="vexpand">true</property>
+                    <property name="vexpand">1</property>
                     <property name="hscrollbar-policy">never</property>
                     <child>
                       <object class="AdwClamp">
@@ -121,11 +118,11 @@
                         <property name="margin-bottom">20</property>
                         <child>
                           <object class="GtkListBox" id="listbox">
-                            <property name="hexpand">true</property>
+                            <property name="hexpand">1</property>
                             <property name="valign">start</property>
                             <property name="selection-mode">none</property>
                             <style>
-                              <class name="boxed-list" />
+                              <class name="boxed-list"/>
                             </style>
                           </object>
                         </child>
@@ -137,10 +134,7 @@
             </child>
           </object>
         </property>
-
       </object>
     </property>
-
   </template>
 </interface>
-


### PR DESCRIPTION
Using the `gtk4-builder-tool`, the UI files were simplified, with lines that set properties to their defaults removed along with whitespace, etc. It also switched bools to `0` and `1`s, but I reverted that since I felt that it was easier to read and understand a bool at a glance, and the point of this was to improve readability and cleanliness. You can close this if you feel it's not important or useful. 