### PR TITLE
Revert compressed file if larger

### DIFF
--- a/src/compressor.py
+++ b/src/compressor.py
@@ -77,6 +77,13 @@ class Compressor():
         GLib.idle_add(self.c_enable_compression, True)
 
     def run_command(self, command, result_item):
+        if not self.do_new_file:
+            # Creates a copy of the input file
+            # This is done in case the output file is larger than the input file
+            result_item_path = Path(result_item.filename)
+            original_filename = Path(result_item.filename).with_stem(f"{result_item_path.stem}-og")
+            shutil.copy2(result_item.filename, original_filename)
+
         error = False
         error_message = ''
         try:
@@ -99,14 +106,16 @@ class Compressor():
                 if new_file_data.is_file():
                     result_item.new_size = new_file_data.stat().st_size
 
-                    # This check is mainly for WebP compression
-                    try:
-                        if result_item.new_size > result_item.size:
+                    # This check is mainly for compressors that don't have a way
+                    # to automatically detect and skip files
+                    if result_item.new_size > result_item.size:
+                        if self.do_new_file:
                             shutil.copy2(result_item.filename, result_item.new_filename)
-                            result_item.new_size = new_file_data.stat().st_size
-                    except shutil.SameFileError as err:
-                        # This will happen with overwrite mode on
-                        pass
+                        else:
+                            shutil.copy2(original_filename, result_item.new_filename)
+                        result_item.new_size = new_file_data.stat().st_size
+                    original_filename.unlink(True)
+
                 else:
                     logging.error(str(output))
                     error_message = _("Can't find the compressed file")

--- a/src/compressor.py
+++ b/src/compressor.py
@@ -18,6 +18,7 @@
 import threading
 import subprocess
 import logging
+import io
 import shutil
 from gi.repository import GLib, Gio
 from pathlib import Path
@@ -80,9 +81,8 @@ class Compressor():
         if not self.do_new_file:
             # Creates a copy of the input file
             # This is done in case the output file is larger than the input file
-            result_item_path = Path(result_item.filename)
-            original_filename = Path(result_item.filename).with_stem(f"{result_item_path.stem}-og")
-            shutil.copy2(result_item.filename, original_filename)
+            temp_filename = result_item.filename + ".temp"
+            shutil.copy2(result_item.filename, temp_filename)
 
         error = False
         error_message = ''
@@ -112,9 +112,9 @@ class Compressor():
                         if self.do_new_file:
                             shutil.copy2(result_item.filename, result_item.new_filename)
                         else:
-                            shutil.copy2(original_filename, result_item.new_filename)
+                            shutil.copy2(temp_filename, result_item.new_filename)
                         result_item.new_size = new_file_data.stat().st_size
-                    original_filename.unlink(True)
+                    Path(temp_filename).unlink(True)
 
                 else:
                     logging.error(str(output))

--- a/src/compressor.py
+++ b/src/compressor.py
@@ -18,7 +18,6 @@
 import threading
 import subprocess
 import logging
-import io
 import shutil
 from gi.repository import GLib, Gio
 from pathlib import Path

--- a/src/compressor.py
+++ b/src/compressor.py
@@ -80,7 +80,9 @@ class Compressor():
         if not self.do_new_file:
             # Creates a copy of the input file
             # This is done in case the output file is larger than the input file
-            temp_filename = result_item.filename + ".temp"
+            index = result_item.filename.find(result_item.name)
+            temp_filename = result_item.filename[:index] + "." + result_item.filename[index:] + ".temp"
+            print(temp_filename)
             shutil.copy2(result_item.filename, temp_filename)
 
         error = False

--- a/src/compressor.py
+++ b/src/compressor.py
@@ -113,8 +113,8 @@ class Compressor():
                             shutil.copy2(result_item.filename, result_item.new_filename)
                         else:
                             shutil.copy2(temp_filename, result_item.new_filename)
+                            Path(temp_filename).unlink(True)
                         result_item.new_size = new_file_data.stat().st_size
-                    Path(temp_filename).unlink(True)
 
                 else:
                     logging.error(str(output))

--- a/src/compressor.py
+++ b/src/compressor.py
@@ -82,7 +82,6 @@ class Compressor():
             # This is done in case the output file is larger than the input file
             index = result_item.filename.find(result_item.name)
             temp_filename = result_item.filename[:index] + "." + result_item.filename[index:] + ".temp"
-            print(temp_filename)
             shutil.copy2(result_item.filename, temp_filename)
 
         error = False


### PR DESCRIPTION
Oxipng and jpegoptim already skip over files that'll be larger by default. pngquant has an option to skip them if larger, which I added. cwebp doesn't have any option for this as far as I know, so the file has to be reverted manually. I'm not sure if there's a cleaner way to do it. The attached image shows the result of a file being skipped/reverted.

I'm also not sure if scour has an option to skip files if they'll end up being larger, but if #227 gets fixed, that won't be a problem. The check I added should catch compressed SVG files that end up being larger anyway.

~~This currently doesn't properly handle reverting files while in overwrite mode. I'll implement that when I have the time.~~ (Done).

![result](https://github.com/Huluti/Curtail/assets/99846997/02b52507-e2fd-4846-8d28-8760f325e130)


Closes #172