### PR TITLE
Change output mode directly from warning banner button

### DIFF
--- a/data/ui/window.ui
+++ b/data/ui/window.ui
@@ -45,7 +45,7 @@
             <property name="orientation">vertical</property>
             <child>
               <object class="AdwBanner" id="warning_banner">
-                <property name="action-name">win.preferences</property>
+                <property name="action-name">win.banner-change-mode</property>
                 <property name="button-label" translatable="yes">_Change Mode</property>
                 <property name="title" translatable="yes">Images will be overwritten, proceed carefully</property>
               </object>

--- a/src/window.py
+++ b/src/window.py
@@ -102,6 +102,7 @@ class CurtailWindow(Adw.ApplicationWindow):
     def create_actions(self):
         self.create_simple_action('select-file', self.on_select, '<Primary>o')
         self.create_simple_action('clear-results', self.clear_results)
+        self.create_simple_action('banner-change-mode', self.banner_change_mode)
         self.create_simple_action('preferences', self.on_preferences, '<Primary>comma')
         self.create_simple_action('about', self.on_about)
         self.create_simple_action('quit', self.on_quit, '<Primary>q')
@@ -346,6 +347,10 @@ class CurtailWindow(Adw.ApplicationWindow):
 
     def on_lossy_changed(self, switch, state):
         self._settings.set_boolean('lossy', switch.get_active())
+
+    def banner_change_mode(self, *args):
+        self._settings.set_boolean('new-file', True)
+        self.show_warning_banner()
 
     def on_preferences(self, *args):
         if self.prefs_dialog is not None:


### PR DESCRIPTION
Rather than the overwrite banner button taking you to the preferences dialog, it automatically enables safe mode. This is just a small QOL thing.