### PR TITLE
Properly update headerbar subtitle when changing mode with banner button

### DIFF
--- a/src/window.py
+++ b/src/window.py
@@ -351,6 +351,7 @@ class CurtailWindow(Adw.ApplicationWindow):
     def banner_change_mode(self, *args):
         self._settings.set_boolean('new-file', True)
         self.show_warning_banner()
+        self.set_saving_subtitle()
 
     def on_preferences(self, *args):
         if self.prefs_dialog is not None:


### PR DESCRIPTION
The headerbar subtitle wouldn't change its label when the output mode was changed with the banner button due to an oversight on my part. Thankfully it's an easy fix.