### PR TITLE
Add minimum window size

### DIFF
--- a/data/ui/window.ui
+++ b/data/ui/window.ui
@@ -4,6 +4,8 @@
     <property name="title" translatable="yes">Curtail</property>
     <property name="default-width">650</property>
     <property name="default-height">500</property>
+    <property name="width-request">360</property>
+    <property name="height-request">294</property>
     <property name="content">
       <object class="AdwToastOverlay" id="toast_overlay">
         <property name="child">


### PR DESCRIPTION
Adds a minimum window size that complies with GNOME'S HIG. See [here](https://developer.gnome.org/hig/guidelines/adaptive.html#small-size-handling) for more details.