### PR TITLE
metainfo: remove unavailable screenshot

### DIFF
--- a/data/com.github.huluti.Curtail.appdata.xml.in
+++ b/data/com.github.huluti.Curtail.appdata.xml.in
@@ -31,9 +31,6 @@
     <screenshot>
       <image type="source">https://raw.githubusercontent.com/Huluti/Curtail/master/data/screenshots/screen2.png</image>
     </screenshot>
-    <screenshot>
-      <image type="source">https://raw.githubusercontent.com/Huluti/Curtail/master/data/screenshots/screen3.png</image>
-    </screenshot>
   </screenshots>
   <translation type="gettext">curtail</translation>
   <launchable type="desktop-id">com.github.huluti.Curtail.desktop</launchable>


### PR DESCRIPTION
The third screenshot was removed in commit 43f154befab5c6b345e5fb053538233142ea0501.