### PR TITLE
preferences: Port to new libadwaita row widgets

### DIFF
--- a/data/ui/preferences.ui
+++ b/data/ui/preferences.ui
@@ -10,15 +10,9 @@
         <child>
           <object class="AdwPreferencesGroup">
             <child>
-              <object class="AdwActionRow">
+              <object class="AdwSwitchRow" id="toggle_new_file">
                 <property name="title" translatable="yes">Safe Mode</property>
                 <property name="subtitle" translatable="yes">Save the compressed image in a new file</property>
-                <property name="activatable-widget">toggle_new_file</property>
-                <child>
-                  <object class="GtkSwitch" id="toggle_new_file">
-                    <property name="valign">center</property>
-                  </object>
-                </child>
               </object>
             </child>
             <child>
@@ -27,59 +21,35 @@
               </object>
             </child>
             <child>
-              <object class="AdwActionRow">
+              <object class="AdwSwitchRow" id="toggle_recursive">
                 <property name="title" translatable="yes">Recursive Compression</property>
                 <property name="subtitle" translatable="yes">Enable or disable compression through subdirectories</property>
-                <property name="activatable-widget">toggle_recursive</property>
-                <child>
-                  <object class="GtkSwitch" id="toggle_recursive">
-                    <property name="valign">center</property>
-                  </object>
-                </child>
               </object>
             </child>
             <child>
-              <object class="AdwActionRow">
+              <object class="AdwSwitchRow" id="toggle_metadata">
                 <property name="title" translatable="yes">Keep Metadata</property>
                 <property name="subtitle" translatable="yes">Keep metadata chunks that do not affect rendering</property>
-                <property name="activatable-widget">toggle_metadata</property>
-                <child>
-                  <object class="GtkSwitch" id="toggle_metadata">
-                    <property name="valign">center</property>
-                  </object>
-                </child>
               </object>
             </child>
             <child>
-              <object class="AdwActionRow">
+              <object class="AdwSwitchRow" id="toggle_file_attributes">
                 <property name="title" translatable="yes">Keep File Attributes When Possible</property>
                 <property name="subtitle" translatable="yes">Ensure the new file has the same permissions and timestamps as the original file</property>
-                <property name="activatable-widget">toggle_file_attributes</property>
-                <child>
-                  <object class="GtkSwitch" id="toggle_file_attributes">
-                    <property name="valign">center</property>
-                  </object>
-                </child>
               </object>
             </child>
             <child>
-              <object class="AdwActionRow">
+              <object class="AdwSpinRow" id="spin_timeout">
                 <property name="title" translatable="yes">Compression Timeout</property>
                 <property name="subtitle" translatable="yes">Set the timeout between images</property>
-                <property name="activatable-widget">spin_timeout</property>
-                <child>
-                  <object class="GtkSpinButton" id="spin_timeout">
-                    <property name="adjustment">
-                      <object class="GtkAdjustment" id="timeout">
-                        <property name="lower">1</property>
-                        <property name="upper">100</property>
-                        <property name="step-increment">1</property>
-                        <property name="page-increment">10</property>
-                      </object>
-                    </property>
-                    <property name="valign">center</property>
-                  </object>
-                </child>
+                  <property name="adjustment">
+                    <object class="GtkAdjustment" id="timeout">
+                      <property name="lower">1</property>
+                      <property name="upper">100</property>
+                      <property name="step-increment">1</property>
+                      <property name="page-increment">10</property>
+                    </object>
+                  </property>
               </object>
             </child>
           </object>
@@ -95,41 +65,29 @@
           <object class="AdwPreferencesGroup">
             <property name="title" translatable="no">PNG</property>
             <child>
-              <object class="AdwActionRow">
+              <object class="AdwSpinRow" id="spin_png_lossy_level">
                 <property name="title" translatable="yes">Lossy Compression</property>
                 <property name="subtitle" translatable="yes">Set the quality of the generated image, 100 is the best quality</property>
-                <property name="activatable-widget">spin_png_lossy_level</property>
-                <child>
-                  <object class="GtkSpinButton" id="spin_png_lossy_level">
-                    <property name="adjustment">
-                      <object class="GtkAdjustment" id="png_lossy_adj">
-                        <property name="upper">100</property>
-                        <property name="step-increment">1</property>
-                        <property name="page-increment">10</property>
-                      </object>
-                    </property>
-                    <property name="valign">center</property>
+                <property name="adjustment">
+                  <object class="GtkAdjustment" id="png_lossy_adj">
+                    <property name="upper">100</property>
+                    <property name="step-increment">1</property>
+                    <property name="page-increment">10</property>
                   </object>
-                </child>
+                </property>
               </object>
             </child>
             <child>
-              <object class="AdwActionRow">
+              <object class="AdwSpinRow" id="spin_png_lossless_level">
                 <property name="title" translatable="yes">Lossless Compression Level</property>
                 <property name="subtitle" translatable="yes">Set the level of the compression, 6 is the highest but slowest level</property>
-                <property name="activatable-widget">spin_png_lossless_level</property>
-                <child>
-                  <object class="GtkSpinButton" id="spin_png_lossless_level">
-                    <property name="adjustment">
-                      <object class="GtkAdjustment" id="png_lossless_adj">
-                        <property name="upper">6</property>
-                        <property name="step-increment">1</property>
-                        <property name="page-increment">10</property>
-                      </object>
-                    </property>
-                    <property name="valign">center</property>
+                <property name="adjustment">
+                  <object class="GtkAdjustment" id="png_lossless_adj">
+                    <property name="upper">6</property>
+                    <property name="step-increment">1</property>
+                    <property name="page-increment">10</property>
                   </object>
-                </child>
+                </property>
               </object>
             </child>
           </object>
@@ -138,34 +96,22 @@
           <object class="AdwPreferencesGroup">
             <property name="title" translatable="no">JPG</property>
             <child>
-              <object class="AdwActionRow">
+              <object class="AdwSpinRow" id="spin_jpg_lossy_level">
                 <property name="title" translatable="yes">Lossy Compression</property>
                 <property name="subtitle" translatable="yes">Set the quality of the generated image, 100 is the best quality</property>
-                <property name="activatable-widget">spin_jpg_lossy_level</property>
-                <child>
-                  <object class="GtkSpinButton" id="spin_jpg_lossy_level">
-                    <property name="adjustment">
-                      <object class="GtkAdjustment" id="jpg_lossy_adj">
-                        <property name="upper">100</property>
-                        <property name="step-increment">1</property>
-                        <property name="page-increment">10</property>
-                      </object>
-                    </property>
-                    <property name="valign">center</property>
+                <property name="adjustment">
+                  <object class="GtkAdjustment" id="jpg_lossy_adj">
+                    <property name="upper">100</property>
+                    <property name="step-increment">1</property>
+                    <property name="page-increment">10</property>
                   </object>
-                </child>
+                </property>
               </object>
             </child>
             <child>
-              <object class="AdwActionRow">
+              <object class="AdwSwitchRow" id="toggle_jpg_progressive">
                 <property name="title" translatable="yes">Progressive Encode</property>
                 <property name="subtitle" translatable="yes">Enable incremental image rendering, going from blurry to clear</property>
-                <property name="activatable-widget">toggle_jpg_progressive</property>
-                <child>
-                  <object class="GtkSwitch" id="toggle_jpg_progressive">
-                    <property name="valign">center</property>
-                  </object>
-                </child>
               </object>
             </child>
           </object>
@@ -174,41 +120,29 @@
           <object class="AdwPreferencesGroup">
             <property name="title" translatable="no">WebP</property>
             <child>
-              <object class="AdwActionRow">
+              <object class="AdwSpinRow" id="spin_webp_lossy_level">
                 <property name="title" translatable="yes">Lossy Compression</property>
                 <property name="subtitle" translatable="yes">Set the quality of the generated image, 100 is the best quality</property>
-                <property name="activatable-widget">spin_webp_lossy_level</property>
-                <child>
-                  <object class="GtkSpinButton" id="spin_webp_lossy_level">
-                    <property name="adjustment">
-                      <object class="GtkAdjustment" id="webp_lossy_adj">
-                        <property name="upper">100</property>
-                        <property name="step-increment">1</property>
-                        <property name="page-increment">10</property>
-                      </object>
-                    </property>
-                    <property name="valign">center</property>
+                <property name="adjustment">
+                  <object class="GtkAdjustment" id="webp_lossy_adj">
+                    <property name="upper">100</property>
+                    <property name="step-increment">1</property>
+                    <property name="page-increment">10</property>
                   </object>
-                </child>
+                </property>
               </object>
             </child>
             <child>
-              <object class="AdwActionRow">
+              <object class="AdwSpinRow" id="spin_webp_lossless_level">
                 <property name="title" translatable="yes">Lossless Compression Level</property>
                 <property name="subtitle" translatable="yes">Set the level of the compression, 6 is the highest but slowest level</property>
-                <property name="activatable-widget">spin_webp_lossless_level</property>
-                <child>
-                  <object class="GtkSpinButton" id="spin_webp_lossless_level">
-                    <property name="adjustment">
-                      <object class="GtkAdjustment" id="webp_lossless_adj">
-                        <property name="upper">6</property>
-                        <property name="step-increment">1</property>
-                        <property name="page-increment">10</property>
-                      </object>
-                    </property>
-                    <property name="valign">center</property>
+                <property name="adjustment">
+                  <object class="GtkAdjustment" id="webp_lossless_adj">
+                    <property name="upper">6</property>
+                    <property name="step-increment">1</property>
+                    <property name="page-increment">10</property>
                   </object>
-                </child>
+                </property>
               </object>
             </child>
           </object>
@@ -217,14 +151,9 @@
           <object class="AdwPreferencesGroup">
             <property name="title" translatable="no">SVG</property>
             <child>
-              <object class="AdwActionRow">
+              <object class="AdwSwitchRow" id="toggle_svg_maximum_level">
                 <property name="title" translatable="yes">Maximum Compression Level</property>
                 <property name="subtitle" translatable="yes">This can be more destructive for the image</property>
-                <child>
-                  <object class="GtkSwitch" id="toggle_svg_maximum_level">
-                    <property name="valign">center</property>
-                  </object>
-                </child>
               </object>
             </child>
           </object>

--- a/src/preferences.py
+++ b/src/preferences.py
@@ -79,37 +79,37 @@ class CurtailPrefsDialog(Adw.PreferencesDialog):
         # Compression Timeout
         self.spin_timeout.set_value(
             self._settings.get_int('compression-timeout'))
-        self.spin_timeout.connect('value-changed',
+        self.spin_timeout.connect('notify::value',
             self.on_int_changed, 'compression-timeout')
 
         # PNG Lossy Compression Level
         self.spin_png_lossy_level.set_value(
             self._settings.get_int('png-lossy-level'))
-        self.spin_png_lossy_level.connect('value-changed',
+        self.spin_png_lossy_level.connect('notify::value',
             self.on_int_changed, 'png-lossy-level')
 
         # PNG Lossless Compression Level
         self.spin_png_lossless_level.set_value(
             self._settings.get_int('png-lossless-level'))
-        self.spin_png_lossless_level.connect('value-changed',
+        self.spin_png_lossless_level.connect('notify::value',
             self.on_int_changed, 'png-lossless-level')
 
         # WebP Lossless Compression Level
         self.spin_webp_lossless_level.set_value(
             self._settings.get_int('webp-lossless-level'))
-        self.spin_webp_lossless_level.connect('value-changed',
+        self.spin_webp_lossless_level.connect('notify::value',
             self.on_int_changed, 'webp-lossless-level')
 
         # JPG Lossy Compression Level
         self.spin_jpg_lossy_level.set_value(
             self._settings.get_int('jpg-lossy-level'))
-        self.spin_jpg_lossy_level.connect('value-changed',
+        self.spin_jpg_lossy_level.connect('notify::value',
             self.on_int_changed, 'jpg-lossy-level')
 
         # WebP Lossy Compression Level
         self.spin_webp_lossy_level.set_value(
             self._settings.get_int('webp-lossy-level'))
-        self.spin_webp_lossy_level.connect('value-changed',
+        self.spin_webp_lossy_level.connect('notify::value',
             self.on_int_changed, 'webp-lossy-level')
 
         # Progressively Encode JPG
@@ -138,6 +138,6 @@ class CurtailPrefsDialog(Adw.PreferencesDialog):
                 self._settings.reset('suffix')
             self.parent.set_saving_subtitle()
 
-    def on_int_changed(self, spin, key):
+    def on_int_changed(self, spin, _, key):
         self._settings.set_int(key, spin.get_value())
 


### PR DESCRIPTION
Yay, a PR that *removes* more lines of code than it adds! I've ported the preferences window to use [`AdwSwitchRow`][1] and [`AdwSpinRow`][2] throughout, reducing code complexity and bringing the visuals up to date.

| Before | After |
| ------ | ----- |
| ![Screenshot From 2024-09-21 02-08-11](https://github.com/user-attachments/assets/8904d4a7-a5a4-494c-b28c-6f5fd611d878) | ![Screenshot From 2024-09-21 02-14-24](https://github.com/user-attachments/assets/7600d794-9d65-4757-a8d2-0041ae67f8f3) |

[1]: https://gnome.pages.gitlab.gnome.org/libadwaita/doc/main/class.SwitchRow.html
[2]: https://gnome.pages.gitlab.gnome.org/libadwaita/doc/main/class.SpinRow.html