### PR TITLE
Use libadwaita 1.6 changes

### DIFF
--- a/data/ui/window.ui
+++ b/data/ui/window.ui
@@ -4,8 +4,6 @@
     <property name="title" translatable="yes">Curtail</property>
     <property name="default-width">650</property>
     <property name="default-height">500</property>
-    <property name="width-request">360</property>
-    <property name="height-request">294</property>
     <property name="content">
       <object class="AdwToastOverlay" id="toast_overlay">
         <property name="child">

--- a/src/window.py
+++ b/src/window.py
@@ -151,8 +151,7 @@ class CurtailWindow(Adw.ApplicationWindow):
         savings_widget.add_css_class('success')
         row.add_suffix(savings_widget)
 
-        spinner = Gtk.Spinner()
-        spinner.start()
+        spinner = Adw.Spinner()
         row.add_suffix(spinner)
 
         error_image = Gtk.Image.new_from_icon_name('x-circular-symbolic')


### PR DESCRIPTION
Replaces GtkSpinner with the new AdwSpinner widget, and removes the minimum window size since AdwWindow now has a default minimum size of 360x200. This minimum size is different than the one manually set, but I don't think it matters too much since both are HIG-compliant.