### PR TITLE
Fix shell injection prevention

### DIFF
--- a/src/window.py
+++ b/src/window.py
@@ -18,7 +18,6 @@
 from gi.repository import Gtk, Gdk, Gio, GLib, Adw, GObject
 from urllib.parse import unquote
 from pathlib import Path
-from shlex import quote
 
 from .resultitem import ResultItem
 from .preferences import CurtailPrefsDialog
@@ -331,10 +330,6 @@ class CurtailWindow(Adw.ApplicationWindow):
                 new_filename = self.create_new_filename(path)
             else:
                 new_filename = ''
-
-            # Avoid shell injections
-            filename = quote(filename)
-            new_filename = quote(new_filename)
 
             result_item = ResultItem(path.name, filename, new_filename, size)
 


### PR DESCRIPTION
Properly prevent shell injections without breaking anything else. Opted to go with this instead of removing `shell=True` because of the complications it would cause with running multiple commands under certain conditions. Testing would be greatly appreciated, since it's important that this actually still stops shell injection.

Closes #250