### PR TITLE
Use file data to guess content type in addition to extension

### DIFF
--- a/src/tools.py
+++ b/src/tools.py
@@ -62,7 +62,12 @@ def add_filechooser_filters(dialog):
 
 
 def get_file_type(filename):
-    content_type = Gio.content_type_guess(filename=str(filename))[0]
+    # Open the file and read the first few bytes,
+    # and we'll check the file header to determine the file type if we can't by extension
+    with open(filename, "rb") as image:
+        file_header = image.read(0xf)
+
+    content_type = Gio.content_type_guess(filename=str(filename), data=file_header)[0]
     if content_type == 'image/jpeg':
         return 'jpg'
     elif content_type == 'image/png':

--- a/src/window.py
+++ b/src/window.py
@@ -337,7 +337,7 @@ class CurtailWindow(Adw.ApplicationWindow):
             filename = filename.strip('\r\n\x00')  # remove spaces
         return filename
 
-    def check_extension(self, filename):
+    def check_format(self, filename):
         file_type = get_file_type(filename)
         if file_type:
             return file_type in ('png', 'jpg', 'webp', 'svg')
@@ -373,7 +373,7 @@ class CurtailWindow(Adw.ApplicationWindow):
 
             # Check format
             size = path.stat().st_size
-            if not self.check_extension(filename) or size <= 0:
+            if not self.check_format(filename) or size <= 0:
                 error_message = _("Format of this file is not supported.").format(path.name)
 
             if not error_message:


### PR DESCRIPTION
`gio`'s [`content_type_guess`](https://amolenaar.pages.gitlab.gnome.org/pygobject-docs/Gio-2.0/functions.html) can also take in file data to guess the content type based on its magic / header. When an valid image doesn't have a valid file extension, Curtail says it's an unsupported format. This pull request just makes it read the first 16 bytes (or less if the file is somehow smaller than that) and pass that in to `content_type_guess` in addition to the file extension.

When I'm sending an image as an attachment to an email with KMail, I can right click "edit with" which creates a file with a garbage name: e.g. `/tmp/kmail2.VjCAty`. I can now use Curtail with this feature to compress the image in place.