### PR TITLE
Don't add --force flag to JPG compression

### DIFF
--- a/src/compressor.py
+++ b/src/compressor.py
@@ -175,11 +175,11 @@ class Compressor():
 
     def build_jpg_command(self, result_item):
         if self.do_new_file:
-            jpegoptim = 'jpegoptim --max={} -o -f --stdout {} > {}'
-            jpegoptim2 = 'jpegoptim -o -f --stdout {} > {}'
+            jpegoptim = 'jpegoptim --max={} -o --stdout {} > {}'
+            jpegoptim2 = 'jpegoptim -o --stdout {} > {}'
         else:
-            jpegoptim = 'jpegoptim --max={} -o -f {}'
-            jpegoptim2 = 'jpegoptim -o -f {}'
+            jpegoptim = 'jpegoptim --max={} -o {}'
+            jpegoptim2 = 'jpegoptim -o {}'
 
         if self.jpg_progressive:
             jpegoptim += ' --all-progressive'


### PR DESCRIPTION
The --force flag forces compression, even if the output file will be larger than the input file. This removes that flag so files will be properly skipped.

See https://github.com/Huluti/Curtail/issues/267#issuecomment-2508176024