### PR TITLE
Update translate URL in appstream file

### DIFF
--- a/data/com.github.huluti.Curtail.appdata.xml.in
+++ b/data/com.github.huluti.Curtail.appdata.xml.in
@@ -20,7 +20,7 @@
   <url type="bugtracker">https://github.com/Huluti/Curtail/issues</url>
   <url type="vcs-browser">https://github.com/Huluti/Curtail</url>
   <url type="donation">https://liberapay.com/hugoposnic</url>
-  <url type="translate">https://github.com/Huluti/Curtail/tree/master/po</url>
+  <url type="translate">https://l10n.gnome.org/module/Curtail</url>
   <kudos>
     <kudo>ModernToolkit</kudo>
   </kudos>


### PR DESCRIPTION
Translations happen on GNOME Damned Lies: https://l10n.gnome.org/module/Curtail/