### PR TITLE
Use AdwToggleGroup for lossless/lossy selector

### DIFF
--- a/data/ui/window.ui
+++ b/data/ui/window.ui
@@ -61,12 +61,12 @@
                     <child>
                       <object class="GtkBox">
                         <property name="orientation">vertical</property>
+                        <property name="spacing">36</property>
                         <child>
                           <object class="GtkButton">
                             <property name="label" translatable="yes">_Browse Files</property>
                             <property name="halign">center</property>
                             <property name="action-name">win.select-file</property>
-                            <property name="margin-bottom">40</property>
                             <property name="use-underline">1</property>
                             <style>
                               <class name="suggested-action"/>
@@ -75,26 +75,18 @@
                           </object>
                         </child>
                         <child>
-                          <object class="GtkBox">
-                            <property name="spacing">10</property>
+                          <object class="AdwToggleGroup" id="toggle_lossy">
                             <property name="halign">center</property>
-                            <property name="valign">center</property>
                             <child>
-                              <object class="GtkLabel">
-                                <property name="halign">end</property>
+                              <object class="AdwToggle">
                                 <property name="label" translatable="yes">Lossless</property>
+                                <property name="name">lossless</property>
                               </object>
                             </child>
                             <child>
-                              <object class="GtkSwitch" id="toggle_lossy">
-                                <property name="halign">center</property>
-                                <property name="valign">center</property>
-                              </object>
-                            </child>
-                            <child>
-                              <object class="GtkLabel">
-                                <property name="halign">start</property>
+                              <object class="AdwToggle">
                                 <property name="label" translatable="yes">Lossy</property>
+                                <property name="name">lossy</property>
                               </object>
                             </child>
                           </object>

--- a/src/window.py
+++ b/src/window.py
@@ -441,8 +441,8 @@ class CurtailWindow(Adw.ApplicationWindow):
         compressor = Compressor(result_items, self.update_result_item, self.enable_compression)
         GLib.idle_add(compressor.compress_images)
 
-    def on_lossy_changed(self, switch, state):
-        self._settings.set_boolean('lossy', switch.get_active())
+    def on_lossy_changed(self, toggle, state):
+        self._settings.set_boolean("lossy", toggle.get_active_name() == "lossy")
 
     def banner_change_mode(self, *args):
         self._settings.set_boolean('new-file', True)


### PR DESCRIPTION
![curtail](https://github.com/user-attachments/assets/808ef663-26e0-4e58-a546-4fd74ebd92d9)

I also moved the margins from the GtkButton to the GtkBox, and decreased them from 40 -> 36, since GNOME apps usually use multiples of 6 for spacing.

Closes #278